### PR TITLE
fix(midi): randomize scale selection to prevent LLM bias

### DIFF
--- a/midi-bot/bot.py
+++ b/midi-bot/bot.py
@@ -124,12 +124,16 @@ def run_bot(args) -> int:
     scales = load_scales(script_dir / "scales.json")
     instruments = load_instruments(script_dir / "instruments.json")
 
+    # Offer the LLM a random subset of scales each day to prevent
+    # it from gravitating to the same favorites (e.g. Hungarian Minor)
+    llm_scales = random.sample(scales, min(15, len(scales)))
+
     # Generate music parameters via LLM
     logger.info("Generating music parameters via LLM...")
     params = generate_music_params(
         headlines=headlines,
         inspirations=inspirations,
-        scales=scales,
+        scales=llm_scales,
         instruments=instruments,
         model=config["prompt"]["model"],
         temperature=config["prompt"]["temperature"],


### PR DESCRIPTION
## Summary
- LLM kept picking the same scales (Hungarian Minor, etc.) due to training data biases
- Now samples 15 random scales from the full 81 each run before passing to the LLM
- LLM still picks the best fit for the day's headlines, just from a rotating pool

## Test plan
- [x] Existing tests pass (13/13, 1 pre-existing slack_poster mock failure)
- [ ] Verify variety in scale selection over several daily runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)