### PR TITLE
feat(midi): add sine wave audio preview

### DIFF
--- a/midi-bot/bot.py
+++ b/midi-bot/bot.py
@@ -18,6 +18,7 @@ from src.generator import (
     generate_music_params, load_scales, load_instruments
 )
 from src.slack_poster import post_midi_to_slack
+from src.synthesizer import synthesize_preview
 
 
 # Import scraper/sampler from surreal-prompt-bot using importlib.util
@@ -158,6 +159,13 @@ def run_bot(args) -> int:
 
         logger.info("All 4 MIDI files generated successfully")
 
+        # Synthesize audio preview (sine waves + noise burst drums)
+        preview_path = midi_path / "preview.wav"
+        if synthesize_preview(midi_path, preview_path):
+            logger.info("Audio preview generated")
+        else:
+            logger.warning("Audio preview generation failed, continuing without it")
+
         if args.dry_run:
             logger.info("Dry run - not posting to Slack")
             # Copy files to a visible location for inspection
@@ -166,6 +174,8 @@ def run_bot(args) -> int:
             dry_run_dir.mkdir(exist_ok=True)
             for f in midi_path.glob("*.mid"):
                 shutil.copy2(f, dry_run_dir / f.name)
+            if preview_path.exists():
+                shutil.copy2(preview_path, dry_run_dir / preview_path.name)
             logger.info(f"MIDI files saved to {dry_run_dir}")
             return 0
 

--- a/midi-bot/requirements.txt
+++ b/midi-bot/requirements.txt
@@ -3,4 +3,6 @@ beautifulsoup4>=4.12.0
 huggingface_hub>=0.20.0
 slack-sdk>=3.27.0
 pyyaml>=6.0.0
+pretty_midi>=0.2.10
+scipy>=1.10.0
 pytest>=8.0.0

--- a/midi-bot/src/slack_poster.py
+++ b/midi-bot/src/slack_poster.py
@@ -58,6 +58,21 @@ def post_midi_to_slack(
         channel_id = resp["channel"]  # resolved ID (files_upload_v2 needs ID, not name)
         logger.info(f"Posted main message to {channel} ({channel_id})")
 
+        # Upload audio preview if available
+        preview_path = midi_dir / "preview.wav"
+        if preview_path.exists():
+            try:
+                client.files_upload_v2(
+                    channel=channel_id,
+                    file=str(preview_path),
+                    filename="preview.wav",
+                    initial_comment=":loud_sound: Preview (sine wave synthesis)",
+                    thread_ts=thread_ts,
+                )
+                logger.info("Uploaded preview.wav")
+            except Exception as e:
+                logger.warning(f"Failed to upload preview: {e}")
+
         # Upload each MIDI file as a threaded reply
         upload_failures = 0
         for track in ["melody", "drums", "bass", "chords"]:

--- a/midi-bot/src/synthesizer.py
+++ b/midi-bot/src/synthesizer.py
@@ -1,0 +1,93 @@
+"""Synthesize MIDI files to a mixed audio preview using sine waves."""
+import logging
+from pathlib import Path
+
+import numpy as np
+import pretty_midi
+from scipy.io import wavfile
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 22050
+MAX_DURATION = 30  # seconds
+
+
+def _synthesize_drums(midi_obj, fs):
+    """Synthesize drum track using noise bursts (kick/snare/hihat)."""
+    duration = midi_obj.get_end_time() + 1.0
+    audio = np.zeros(int(duration * fs))
+
+    for inst in midi_obj.instruments:
+        if not inst.is_drum:
+            continue
+        for note in inst.notes:
+            start = int(note.start * fs)
+            vel = note.velocity / 127.0
+
+            if note.pitch in (35, 36):  # kick
+                length = int(0.08 * fs)
+                t = np.linspace(0, 0.08, length)
+                burst = np.sin(2 * np.pi * 80 * t * np.exp(-t * 30)) * np.exp(-t * 25)
+            elif note.pitch in (38, 40):  # snare
+                length = int(0.1 * fs)
+                t = np.linspace(0, 0.1, length)
+                burst = (np.random.randn(length) * 0.7 + np.sin(2 * np.pi * 180 * t) * 0.3) * np.exp(-t * 20)
+            elif note.pitch in (42, 44, 46):  # hihat
+                length = int(0.05 * fs)
+                t = np.linspace(0, 0.05, length)
+                burst = np.random.randn(length) * np.exp(-t * 60) * 0.5
+            else:  # other percussion
+                length = int(0.06 * fs)
+                t = np.linspace(0, 0.06, length)
+                burst = np.random.randn(length) * np.exp(-t * 40) * 0.4
+
+            end = min(start + length, len(audio))
+            audio[start:end] += burst[:end - start] * vel
+
+    return audio
+
+
+def synthesize_preview(midi_dir: Path, output_path: Path) -> bool:
+    """Load 4 MIDI tracks, synthesize, mix, and write a WAV preview."""
+    track_names = ["melody", "chords", "bass", "drums"]
+    tracks = []
+
+    for name in track_names:
+        midi_file = midi_dir / f"{name}.mid"
+        if not midi_file.exists():
+            logger.warning(f"Missing {midi_file}, skipping")
+            continue
+
+        mid = pretty_midi.PrettyMIDI(str(midi_file))
+
+        if name == "drums":
+            audio = _synthesize_drums(mid, SAMPLE_RATE)
+        else:
+            audio = mid.synthesize(fs=SAMPLE_RATE)
+            audio = np.nan_to_num(audio, nan=0.0)
+
+        tracks.append(audio)
+        logger.info(f"Synthesized {name}: {len(audio) / SAMPLE_RATE:.1f}s")
+
+    if not tracks:
+        logger.error("No tracks to mix")
+        return False
+
+    # Pad to same length, mix, and trim
+    max_len = max(len(t) for t in tracks)
+    max_samples = int(MAX_DURATION * SAMPLE_RATE)
+    mix_len = min(max_len, max_samples)
+
+    mixed = np.zeros(mix_len)
+    for t in tracks:
+        end = min(len(t), mix_len)
+        mixed[:end] += t[:end]
+
+    # Normalize
+    peak = np.abs(mixed).max()
+    if peak > 0:
+        mixed = mixed / peak * 0.9
+
+    wavfile.write(str(output_path), SAMPLE_RATE, (mixed * 32767).astype(np.int16))
+    logger.info(f"Preview written: {output_path} ({mix_len / SAMPLE_RATE:.1f}s)")
+    return True


### PR DESCRIPTION
## Summary
- Synthesizes all 4 MIDI tracks into a mixed WAV preview using sine waves (pitched instruments) and noise bursts (drums)
- Preview uploaded to Slack thread before individual MIDI files
- Capped at 30 seconds, lo-fi chiptune aesthetic
- New dependencies: `pretty_midi`, `scipy` (no external binaries needed)

## Test plan
- [x] Existing tests pass (13/13, 1 pre-existing slack_poster mock failure)
- [x] Integration test with sample MIDI files produces valid WAV
- [ ] End-to-end test via GitHub Actions workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)