### PR TITLE
fix(midi): LLM can now actually see and choose from scale list

### DIFF
--- a/midi-bot/bot.py
+++ b/midi-bot/bot.py
@@ -125,9 +125,9 @@ def run_bot(args) -> int:
     scales = load_scales(script_dir / "scales.json")
     instruments = load_instruments(script_dir / "instruments.json")
 
-    # Offer the LLM a random subset of scales each day to prevent
-    # it from gravitating to the same favorites (e.g. Hungarian Minor)
-    llm_scales = random.sample(scales, min(15, len(scales)))
+    # Offer the LLM a small curated subset so it actually reads and
+    # chooses intelligently instead of defaulting to its favorites
+    llm_scales = random.sample(scales, min(5, len(scales)))
 
     # Generate music parameters via LLM
     logger.info("Generating music parameters via LLM...")

--- a/midi-bot/prompt_template.txt
+++ b/midi-bot/prompt_template.txt
@@ -1,7 +1,7 @@
 You are a surrealist composer with severe internet brain rot. You select unusual musical parameters inspired by news headlines.
 
 Given the headlines and inspirations below, output a JSON object with these exact keys:
-- "scale": one scale name from the SCALES list below (prefer unusual, non-Western scales — DO NOT keep picking the same ones)
+- "scale": You MUST choose one of the numbered scales below. Copy the name EXACTLY. Do NOT use any scale not on this list.
 - "root": a root note (e.g. "C", "F#", "Bb") — vary this, don't always pick C or A
 - "chords": an array of exactly 4 chord symbols that work with the chosen scale (e.g. ["Am", "Dm7", "G7", "Cmaj7"])
 - "tempo": a number between 40 and 200
@@ -11,8 +11,8 @@ Given the headlines and inspirations below, output a JSON object with these exac
 - "description": a single surreal sentence inspired by the headlines (with 1-3 emojis, Slack formatting allowed)
 
 Output ONLY the JSON. No explanation. No markdown code fence. Just the raw JSON object.
-
-SCALES:
+---
+TODAY'S SCALE OPTIONS (pick ONE — use the exact name):
 {scales}
 
 MELODY INSTRUMENTS:
@@ -20,8 +20,6 @@ MELODY INSTRUMENTS:
 
 CHORD INSTRUMENTS:
 {chord_instruments}
-
----
 
 Today's news headlines:
 {headlines}


### PR DESCRIPTION
## Summary
- **Root cause found**: The `{scales}` placeholder was in the system prompt, which was never formatted — the LLM literally saw `{scales}` as text and always defaulted to Hungarian Minor from its training data
- Moved scales/instruments to the user template where `.format()` actually runs
- Reduced scale sample from 15 to 5 with numbered format and character descriptions
- Character descriptions auto-computed from intervals (sparse/bright/dark/exotic/tense/etc.)
- Stronger prompt: "You MUST choose one of the numbered scales below"

## Test plan
- [x] Verified formatted prompt shows actual scale names with descriptions
- [x] All 13 tests pass
- [ ] End-to-end test: verify LLM picks from the presented list (no validate_params fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)