### PR TITLE
fix(midi): quote scale names, sanitize chord extensions

### DIFF
--- a/midi-bot/src/generator.py
+++ b/midi-bot/src/generator.py
@@ -83,7 +83,7 @@ def build_llm_prompt(
     scales_lines = []
     for i, s in enumerate(scales, 1):
         desc = describe_scale(s)
-        scales_lines.append(f"{i}. {s['name']} ({s['origin']}) — {desc}")
+        scales_lines.append(f'{i}. "{s["name"]}" — {s["origin"]}, {desc}')
     scales_text = "\n".join(scales_lines)
     melody_text = "\n".join(f"- {i['program']}: {i['name']}" for i in instruments["melody"])
     chords_text = "\n".join(f"- {i['program']}: {i['name']}" for i in instruments["chords"])
@@ -161,6 +161,12 @@ def validate_params(
         logger.warning(f"Invalid chords: {params.get('chords')}, using default progression")
         root = params.get("root", "C")
         params["chords"] = [f"{root}m", f"{root}m7", f"{root}m", f"{root}m7"]
+    else:
+        # Strip parenthetical extensions tonal.js can't parse, e.g. E7(b9) → E7
+        sanitized = [re.sub(r'\(.*?\)', '', c) for c in params["chords"]]
+        if sanitized != params["chords"]:
+            logger.warning(f"Simplified chords {params['chords']} → {sanitized}")
+            params["chords"] = sanitized
 
 
 def generate_music_params(


### PR DESCRIPTION
## Summary
- LLM was copying origin text with scale name (e.g. `Diminished (Whole-Half) (Western/Jazz)`) — now names are quoted in the prompt to make the exact string to copy obvious
- Strip parenthetical chord extensions tonal.js can't parse (e.g. `E7(b9)` → `E7`) instead of crashing

## Test plan
- [x] All 13 tests pass
- [x] Prompt format verified: `1. "Gnawa" — North African/Moroccan, dark, 7 notes`
- [ ] End-to-end via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)