### PR TITLE
Fix home link position and size

### DIFF
--- a/puke-box.html
+++ b/puke-box.html
@@ -388,7 +388,7 @@
 </head>
 <body>
 
-<a href="index.html" style="position:fixed;top:8px;left:10px;z-index:10;color:#ff00ff;font-family:'Courier New',monospace;font-size:0.85rem;text-decoration:none;text-shadow:0 0 8px #ff00ff;" onmouseover="this.style.color='#00ffff'" onmouseout="this.style.color='#ff00ff'">&laquo; HOME</a>
+<a href="index.html" style="position:fixed;top:70px;left:10px;z-index:10;color:#ff00ff;font-family:'Courier New',monospace;font-size:1.3rem;text-decoration:none;text-shadow:0 0 8px #ff00ff;" onmouseover="this.style.color='#00ffff'" onmouseout="this.style.color='#ff00ff'">&laquo; HOME</a>
 
 <!-- Top rainbow marquee -->
 <div class="top-marquees">


### PR DESCRIPTION
Larger font (1.3rem) and lowered to 70px to clear the rainbow marquee bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)