### PR TITLE
Fix glottisdale: nonsense words, WAV output, Slack formatting

### DIFF
--- a/glottisdale/pyproject.toml
+++ b/glottisdale/pyproject.toml
@@ -20,3 +20,7 @@ glottisdale = "glottisdale.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src", "slack"]
+testpaths = ["tests"]

--- a/glottisdale/slack/glottisdale_slack/post.py
+++ b/glottisdale/slack/glottisdale_slack/post.py
@@ -18,48 +18,49 @@ def post_results(
     output_dir: Path,
     _client: WebClient | None = None,
 ) -> None:
-    """Post concatenated audio + clips zip to a Slack channel.
+    """Post glottisdale results to a Slack channel.
 
-    Posts a summary message, uploads concatenated.ogg to the thread,
-    and uploads clips.zip as a threaded reply.
+    Uploads concatenated audio + clips zip as the main message,
+    then posts source links in a thread to keep the main post clean.
     """
     client = _client or WebClient(token=token)
 
-    # Build summary text
-    lines = [f":scissors: *Glottisdale* — {len(result.clips)} syllable clips"]
-    lines.append("")
-    lines.append("*Sources:*")
-    for src in sources:
-        name = src.get("name", "unknown")
-        link = src.get("permalink", "")
-        clip_count = len([c for c in result.clips if c.source == Path(name).stem])
-        if link:
-            lines.append(f"  - <{link}|{name}> ({clip_count} clips)")
-        else:
-            lines.append(f"  - {name} ({clip_count} clips)")
+    summary = f":scissors: *Glottisdale* — {len(result.clips)} words from {len(sources)} source(s)"
 
-    summary = "\n".join(lines)
-
-    # Post summary
-    resp = client.chat_postMessage(channel=channel, text=summary)
-    thread_ts = resp["ts"]
-    channel_id = resp["channel"]
-
-    # Upload concatenated audio
+    # Upload concatenated audio as the main post
     concat_path = result.concatenated
+    thread_ts = None
+    channel_id = None
+
     if concat_path.exists():
         try:
-            client.files_upload_v2(
-                channel=channel_id,
+            resp = client.files_upload_v2(
+                channel=channel,
                 file=str(concat_path),
-                filename="glottisdale.ogg",
-                initial_comment="Concatenated syllable collage",
-                thread_ts=thread_ts,
+                filename="glottisdale.wav",
+                initial_comment=summary,
             )
+            # Get thread_ts from the message that was created
+            if resp.get("file") and resp["file"].get("shares"):
+                shares = resp["file"]["shares"]
+                for share_type in ("public", "private"):
+                    for ch_id, msgs in shares.get(share_type, {}).items():
+                        if msgs:
+                            thread_ts = msgs[0].get("ts")
+                            channel_id = ch_id
+                            break
+                    if thread_ts:
+                        break
         except Exception:
             logger.exception("Failed to upload concatenated audio")
 
-    # Upload clips zip
+    # Fall back to a text message if upload failed
+    if not thread_ts:
+        resp = client.chat_postMessage(channel=channel, text=summary)
+        thread_ts = resp["ts"]
+        channel_id = resp["channel"]
+
+    # Upload clips zip in thread
     zip_path = output_dir / "clips.zip"
     if zip_path.exists():
         try:
@@ -67,8 +68,28 @@ def post_results(
                 channel=channel_id,
                 file=str(zip_path),
                 filename="clips.zip",
-                initial_comment="Individual syllable clips",
+                initial_comment="Individual word clips",
                 thread_ts=thread_ts,
             )
         except Exception:
             logger.exception("Failed to upload clips zip")
+
+    # Post source links in thread
+    if sources:
+        source_lines = ["*Sources:*"]
+        for src in sources:
+            name = src.get("name", "unknown")
+            link = src.get("permalink", "")
+            clip_count = len([c for c in result.clips if c.source == Path(name).stem])
+            if link:
+                source_lines.append(f"  - <{link}|{name}> ({clip_count} words)")
+            else:
+                source_lines.append(f"  - {name} ({clip_count} words)")
+        try:
+            client.chat_postMessage(
+                channel=channel_id,
+                text="\n".join(source_lines),
+                thread_ts=thread_ts,
+            )
+        except Exception:
+            logger.exception("Failed to post source links")

--- a/glottisdale/src/glottisdale/__init__.py
+++ b/glottisdale/src/glottisdale/__init__.py
@@ -18,6 +18,15 @@ from glottisdale.audio import (
 from glottisdale.types import Clip, Result, Syllable
 
 
+def _parse_range(s: str) -> tuple[int, int]:
+    """Parse range string like '1-5' or '3' into (min, max)."""
+    if "-" in s:
+        parts = s.split("-", 1)
+        return int(parts[0]), int(parts[1])
+    val = int(s)
+    return val, val
+
+
 def _parse_gap(gap: str) -> tuple[float, float]:
     """Parse gap string like '50-200' or '100' into (min_ms, max_ms)."""
     if "-" in gap:
@@ -92,11 +101,11 @@ def _sample_syllables_multi_source(
 def process(
     input_paths: list[Path],
     output_dir: str | Path = "./glottisdale-output",
-    syllables_per_clip: int = 1,
+    syllables_per_clip: str = "1-5",
     target_duration: float = 10.0,
     crossfade_ms: float = 10,
     padding_ms: float = 25,
-    gap: str = "50-200",
+    gap: str = "200-500",
     aligner: str = "default",
     whisper_model: str = "base",
     seed: int | None = None,
@@ -108,6 +117,7 @@ def process(
     clips_dir.mkdir(parents=True, exist_ok=True)
 
     gap_min, gap_max = _parse_gap(gap)
+    spc_min, spc_max = _parse_range(syllables_per_clip)
     alignment_engine = get_aligner(aligner, whisper_model=whisper_model)
 
     # Process each input file
@@ -141,63 +151,82 @@ def process(
                 all_syllables, target_duration, rng
             )
 
-        # Group syllables into clips
+        # Helper to find which source a syllable came from
+        def _find_source(syl: Syllable) -> str:
+            for src_name, src_syls in all_syllables.items():
+                if syl in src_syls:
+                    return src_name
+            return "unknown"
+
+        # Group syllables into variable-length nonsense "words"
+        words: list[list[Syllable]] = []
+        i = 0
+        while i < len(selected):
+            word_len = rng.randint(spc_min, spc_max)
+            word = selected[i:i + word_len]
+            if word:
+                words.append(word)
+            i += word_len
+
+        # Build each word: cut individual syllables, fuse them tightly
         clips = []
-        for i in range(0, len(selected), syllables_per_clip):
-            group = selected[i:i + syllables_per_clip]
-            if not group:
+        for word_idx, word_syls in enumerate(words):
+            # Cut each syllable from its source audio
+            syl_clip_paths = []
+            for syl_idx, syl in enumerate(word_syls):
+                syl_source = _find_source(syl)
+                source_audio = tmpdir / f"{syl_source}.wav"
+                syl_clip_path = tmpdir / f"word{word_idx:03d}_syl{syl_idx:02d}.wav"
+                if source_audio.exists():
+                    cut_clip(
+                        input_path=source_audio,
+                        output_path=syl_clip_path,
+                        start=syl.start,
+                        end=syl.end,
+                        padding_ms=padding_ms,
+                        fade_ms=0,
+                    )
+                    syl_clip_paths.append(syl_clip_path)
+
+            if not syl_clip_paths:
                 continue
 
-            clip_start = min(s.start for s in group)
-            clip_end = max(s.end for s in group)
-            # Find which source file this syllable came from
-            clip_source = "unknown"
-            for src_name, src_syls in all_syllables.items():
-                if group[0] in src_syls:
-                    clip_source = src_name
-                    break
-
-            clip_idx = len(clips) + 1
-            w_idx = group[0].word_index
-            s_idx = 0
-            filename = f"{clip_idx:03d}_{clip_source}_w{w_idx:02d}_s{s_idx:02d}.ogg"
-            output_path = clips_dir / filename
-
-            clips.append(Clip(
-                syllables=group,
-                start=clip_start,
-                end=clip_end,
-                source=clip_source,
-                output_path=output_path,
-            ))
-
-        # Cut each clip from its source audio
-        for clip in clips:
-            source_audio = tmpdir / f"{clip.source}.wav"
-            if source_audio.exists():
-                cut_clip(
-                    input_path=source_audio,
-                    output_path=clip.output_path,
-                    start=clip.syllables[0].start,
-                    end=clip.syllables[-1].end,
-                    padding_ms=padding_ms,
-                    fade_ms=10,
+            # Fuse syllables tightly into one "word" clip
+            word_filename = f"{word_idx + 1:03d}_word.wav"
+            word_output = clips_dir / word_filename
+            if len(syl_clip_paths) == 1:
+                shutil.copy2(syl_clip_paths[0], word_output)
+            else:
+                concatenate_clips(
+                    syl_clip_paths, word_output,
+                    crossfade_ms=crossfade_ms,
                 )
 
-        # Generate gap durations
+            # Track dominant source for metadata
+            word_sources = [_find_source(s) for s in word_syls]
+            dominant = max(set(word_sources), key=word_sources.count)
+
+            clips.append(Clip(
+                syllables=word_syls,
+                start=min(s.start for s in word_syls),
+                end=max(s.end for s in word_syls),
+                source=dominant,
+                output_path=word_output,
+            ))
+
+        # Concatenate words with silence gaps between them
         gap_durations = []
         if len(clips) > 1:
             for _ in range(len(clips) - 1):
                 gap_durations.append(rng.uniform(gap_min, gap_max))
 
-        # Concatenate
-        concatenated_path = output_dir / "concatenated.ogg"
+        concatenated_path = output_dir / "concatenated.wav"
         clip_paths = [c.output_path for c in clips if c.output_path.exists()]
         if clip_paths:
             concatenate_clips(
                 clip_paths,
                 concatenated_path,
-                crossfade_ms=crossfade_ms,
+                crossfade_ms=0,
                 gap_durations_ms=gap_durations if gap_durations else None,
             )
 

--- a/glottisdale/src/glottisdale/audio.py
+++ b/glottisdale/src/glottisdale/audio.py
@@ -84,20 +84,20 @@ def cut_clip(
     ]
     if filters:
         cmd.extend(["-af", ",".join(filters)])
-    cmd.extend(["-c:a", "libvorbis", "-q:a", "4", str(output_path)])
+    cmd.extend(["-c:a", "pcm_s16le", str(output_path)])
 
     subprocess.run(cmd, capture_output=True, text=True, timeout=30).check_returncode()
     return output_path
 
 
 def generate_silence(output_path: Path, duration_ms: float, sample_rate: int = 16000) -> Path:
-    """Generate a silent OGG file."""
+    """Generate a silent WAV file."""
     duration_s = duration_ms / 1000.0
     cmd = [
         "ffmpeg", "-y",
         "-f", "lavfi", "-i", f"anullsrc=r={sample_rate}:cl=mono",
         "-t", f"{duration_s:.4f}",
-        "-c:a", "libvorbis", "-q:a", "4",
+        "-c:a", "pcm_s16le",
         str(output_path),
     ]
     subprocess.run(cmd, capture_output=True, text=True, timeout=30).check_returncode()
@@ -131,7 +131,7 @@ def concatenate_clips(
             if gap_durations_ms and i < len(clip_paths) - 1:
                 gap_ms = gap_durations_ms[i] if i < len(gap_durations_ms) else 0
                 if gap_ms > 0:
-                    silence_path = tmpdir / f"silence_{i:04d}.ogg"
+                    silence_path = tmpdir / f"silence_{i:04d}.wav"
                     generate_silence(silence_path, gap_ms)
                     concat_list.append(silence_path)
 
@@ -193,7 +193,7 @@ def _concatenate_with_crossfade(
     cmd = ["ffmpeg", "-y"] + inputs + [
         "-filter_complex", ";".join(filter_parts),
         "-map", "[out]",
-        "-c:a", "libvorbis", "-q:a", "4",
+        "-c:a", "pcm_s16le",
         str(output_path),
     ]
     subprocess.run(cmd, capture_output=True, text=True, timeout=120).check_returncode()

--- a/glottisdale/src/glottisdale/cli.py
+++ b/glottisdale/src/glottisdale/cli.py
@@ -21,16 +21,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     # Core options
     parser.add_argument("--output-dir", default="./glottisdale-output",
                         help="Output directory (default: ./glottisdale-output)")
-    parser.add_argument("--syllables-per-clip", type=int, default=1,
-                        help="Syllables per clip (default: 1)")
+    parser.add_argument("--syllables-per-clip", default="1-5",
+                        help="Syllables per word: '3', or '1-5' for variable (default: 1-5)")
     parser.add_argument("--target-duration", type=float, default=10.0,
                         help="Target total duration in seconds (default: 10)")
     parser.add_argument("--crossfade", type=float, default=10,
                         help="Crossfade between clips in ms (default: 10, 0=hard cut)")
     parser.add_argument("--padding", type=float, default=25,
                         help="Padding around syllable cuts in ms (default: 25)")
-    parser.add_argument("--gap", default="50-200",
-                        help="Silence between clips in ms: '0', '100', or '50-200' (default: 50-200)")
+    parser.add_argument("--gap", default="200-500",
+                        help="Silence between words in ms: '0', '300', or '200-500' (default: 200-500)")
     parser.add_argument("--whisper-model", default="base",
                         choices=["tiny", "base", "small", "medium"],
                         help="Whisper model size (default: base)")

--- a/glottisdale/tests/test_audio.py
+++ b/glottisdale/tests/test_audio.py
@@ -43,7 +43,7 @@ from glottisdale.audio import cut_clip, generate_silence, concatenate_clips
 
 def test_cut_clip(tmp_path):
     """Cut a 0.5s clip from a 2s source."""
-    out = tmp_path / "clip.ogg"
+    out = tmp_path / "clip.wav"
     cut_clip(
         input_path=FIXTURES / "test_tone.wav",
         output_path=out,
@@ -59,7 +59,7 @@ def test_cut_clip(tmp_path):
 
 def test_cut_clip_with_padding(tmp_path):
     """Padding extends the clip by padding_ms on each side."""
-    out = tmp_path / "clip.ogg"
+    out = tmp_path / "clip.wav"
     cut_clip(
         input_path=FIXTURES / "test_tone.wav",
         output_path=out,
@@ -76,7 +76,7 @@ def test_cut_clip_with_padding(tmp_path):
 
 def test_cut_clip_padding_clamped(tmp_path):
     """Padding at file boundaries is clamped."""
-    out = tmp_path / "clip.ogg"
+    out = tmp_path / "clip.wav"
     cut_clip(
         input_path=FIXTURES / "test_tone.wav",
         output_path=out,
@@ -90,8 +90,8 @@ def test_cut_clip_padding_clamped(tmp_path):
 
 
 def test_generate_silence(tmp_path):
-    """Generate a silent OGG of specified duration."""
-    out = tmp_path / "silence.ogg"
+    """Generate a silent WAV of specified duration."""
+    out = tmp_path / "silence.wav"
     generate_silence(out, duration_ms=100, sample_rate=16000)
     assert out.exists()
     duration = get_duration(out)
@@ -101,12 +101,12 @@ def test_generate_silence(tmp_path):
 def test_concatenate_clips_no_gaps(tmp_path):
     """Concatenate two clips without gaps."""
     # Cut two clips from test tone
-    clip1 = tmp_path / "c1.ogg"
-    clip2 = tmp_path / "c2.ogg"
+    clip1 = tmp_path / "c1.wav"
+    clip2 = tmp_path / "c2.wav"
     cut_clip(FIXTURES / "test_tone.wav", clip1, 0.0, 0.5, padding_ms=0, fade_ms=0)
     cut_clip(FIXTURES / "test_tone.wav", clip2, 0.5, 1.0, padding_ms=0, fade_ms=0)
 
-    out = tmp_path / "concat.ogg"
+    out = tmp_path / "concat.wav"
     concatenate_clips([clip1, clip2], out, crossfade_ms=0)
     assert out.exists()
     duration = get_duration(out)
@@ -115,12 +115,12 @@ def test_concatenate_clips_no_gaps(tmp_path):
 
 def test_concatenate_with_gaps(tmp_path):
     """Concatenate with silence gaps."""
-    clip1 = tmp_path / "c1.ogg"
-    clip2 = tmp_path / "c2.ogg"
+    clip1 = tmp_path / "c1.wav"
+    clip2 = tmp_path / "c2.wav"
     cut_clip(FIXTURES / "test_tone.wav", clip1, 0.0, 0.3, padding_ms=0, fade_ms=0)
     cut_clip(FIXTURES / "test_tone.wav", clip2, 0.5, 0.8, padding_ms=0, fade_ms=0)
 
-    out = tmp_path / "concat.ogg"
+    out = tmp_path / "concat.wav"
     concatenate_clips([clip1, clip2], out, crossfade_ms=0, gap_durations_ms=[200])
     assert out.exists()
     duration = get_duration(out)

--- a/glottisdale/tests/test_cli.py
+++ b/glottisdale/tests/test_cli.py
@@ -15,11 +15,11 @@ def test_parse_local_files():
 def test_parse_defaults():
     args = parse_args([])
     assert args.output_dir == "./glottisdale-output"
-    assert args.syllables_per_clip == 1
+    assert args.syllables_per_clip == "1-5"
     assert args.target_duration == 10.0
     assert args.crossfade == 10
     assert args.padding == 25
-    assert args.gap == "50-200"
+    assert args.gap == "200-500"
     assert args.whisper_model == "base"
     assert args.aligner == "default"
     assert args.seed is None
@@ -39,7 +39,7 @@ def test_parse_all_options():
         "input.mp4",
     ])
     assert args.output_dir == "/tmp/out"
-    assert args.syllables_per_clip == 3
+    assert args.syllables_per_clip == "3"
     assert args.target_duration == 30.0
     assert args.crossfade == 0
     assert args.padding == 50

--- a/glottisdale/tests/test_integration.py
+++ b/glottisdale/tests/test_integration.py
@@ -58,10 +58,10 @@ def test_full_pipeline_local_mode(mock_transcribe, tmp_path):
     assert manifest["sources"] == ["input"]
     assert len(manifest["clips"]) > 0
 
-    # Verify clips are real OGG files
+    # Verify clips are real WAV files
     for clip in result.clips:
         assert clip.output_path.exists()
         assert clip.output_path.stat().st_size > 0
 
-    # "hello" = 2 syllables, "beautiful" = 3 syllables, "world" = 1 syllable = 6 total
-    assert len(result.clips) >= 3  # at least some syllables selected
+    # 6 syllables grouped into variable-length words — at least 2 words
+    assert len(result.clips) >= 2

--- a/glottisdale/tests/test_pipeline.py
+++ b/glottisdale/tests/test_pipeline.py
@@ -68,7 +68,7 @@ def test_process_local_file(
     )
 
     assert result.transcript == "[audio] hello world"
-    assert len(result.clips) == 3
+    assert len(result.clips) >= 1  # 3 syllables grouped into variable-length words
     assert result.concatenated.exists()
     assert (tmp_path / "out" / "manifest.json").exists()
 

--- a/glottisdale/tests/test_slack_post.py
+++ b/glottisdale/tests/test_slack_post.py
@@ -7,40 +7,55 @@ from glottisdale_slack.post import post_results
 from glottisdale.types import Result, Clip, Syllable, Phoneme
 
 
-def test_post_results():
+def test_post_results(tmp_path):
     client = MagicMock()
-    client.chat_postMessage.return_value = {
-        "ts": "111.222",
-        "channel": "C999",
+    # files_upload_v2 returns file share info so we can get thread_ts
+    client.files_upload_v2.return_value = {
+        "file": {
+            "shares": {
+                "public": {
+                    "C999": [{"ts": "111.222"}]
+                }
+            }
+        }
     }
+
+    # Create real files so the upload paths exist
+    concat_path = tmp_path / "concatenated.wav"
+    concat_path.touch()
+    zip_path = tmp_path / "clips.zip"
+    zip_path.touch()
 
     result = Result(
         clips=[
             Clip(
                 syllables=[Syllable([Phoneme("AH0", 0.0, 0.1)], 0.0, 0.1, "test", 0)],
                 start=0.0, end=0.1, source="video1",
-                output_path=Path("/tmp/clips/001_video1_w00_s00.ogg"),
+                output_path=tmp_path / "clips" / "001_word.wav",
             ),
         ],
-        concatenated=Path("/tmp/concatenated.ogg"),
+        concatenated=concat_path,
         transcript="test",
         manifest={},
     )
 
     sources = [{"name": "video1.mp4", "permalink": "https://slack.com/archives/C001/p123"}]
 
-    # Mock file existence
     post_results(
         token="xoxb-test",
         channel="#glottisdale",
         result=result,
         sources=sources,
-        output_dir=Path("/tmp"),
-        _client=client,  # inject mock
+        output_dir=tmp_path,
+        _client=client,
     )
 
-    # Should post summary message
-    client.chat_postMessage.assert_called_once()
-    msg_text = client.chat_postMessage.call_args[1]["text"]
-    assert "video1.mp4" in msg_text
-    assert "1 syllable clips" in msg_text
+    # Main upload should be the concatenated audio (no thread_ts)
+    first_upload = client.files_upload_v2.call_args_list[0]
+    assert "glottisdale.wav" in str(first_upload)
+    assert "thread_ts" not in first_upload[1]
+
+    # Source links should be in thread
+    thread_msg = client.chat_postMessage.call_args_list[0]
+    assert thread_msg[1]["thread_ts"] == "111.222"
+    assert "video1.mp4" in thread_msg[1]["text"]


### PR DESCRIPTION
## Summary
- **Nonsense words**: Syllables are now fused tightly into variable-length (1-5) nonsense "words" with crossfade, then words are separated by silence gaps (200-500ms). Output sounds like gibberish speech instead of rapid-fire syllable scanning.
- **WAV output**: Switched from OGG to WAV for Slack preview/playback support.
- **Slack formatting**: Concatenated audio + clips zip uploaded as the main message. Source links posted in a thread to keep things clean.

## Test plan
- [x] 35/35 tests passing locally
- [ ] Trigger GitHub Action and verify output in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)