### PR TITLE
Increase default glottisdale duration to 30s

### DIFF
--- a/.github/workflows/glottisdale.yml
+++ b/.github/workflows/glottisdale.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       target_duration:
         description: 'Target duration in seconds'
-        default: '10'
+        default: '30'
       max_videos:
         description: 'Max source videos'
         default: '5'

--- a/glottisdale/src/glottisdale/cli.py
+++ b/glottisdale/src/glottisdale/cli.py
@@ -26,8 +26,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                         help="Syllables per word: '3', or '1-4' for variable (default: 1-4)")
     parser.add_argument("--syllables-per-clip", default=None,
                         help=argparse.SUPPRESS)  # deprecated alias
-    parser.add_argument("--target-duration", type=float, default=10.0,
-                        help="Target total duration in seconds (default: 10)")
+    parser.add_argument("--target-duration", type=float, default=30.0,
+                        help="Target total duration in seconds (default: 30)")
     parser.add_argument("--crossfade", type=float, default=10,
                         help="Crossfade between syllables in a word, ms (default: 10, 0=hard cut)")
     parser.add_argument("--padding", type=float, default=25,


### PR DESCRIPTION
## Summary
- Changes default `--target-duration` from 10s to 30s in CLI and workflow

## Test plan
- [x] Verified CLI default updated
- [x] Verified workflow default updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)