### PR TITLE
fix(glottisdale): add scipy dependency for CI

### DIFF
--- a/.github/workflows/glottisdale.yml
+++ b/.github/workflows/glottisdale.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         run: |
-          ARGS="--target-duration ${{ inputs.target_duration || '10' }}"
+          ARGS="--target-duration ${{ inputs.target_duration || '30' }}"
           ARGS="$ARGS --max-videos ${{ inputs.max_videos || '5' }}"
           ARGS="$ARGS --whisper-model ${{ inputs.whisper_model || 'base' }}"
           if [ -n "${{ inputs.seed }}" ]; then

--- a/glottisdale/pyproject.toml
+++ b/glottisdale/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10"
 dependencies = [
     "openai-whisper",
     "g2p_en",
+    "scipy",
 ]
 
 [project.optional-dependencies]

--- a/glottisdale/requirements.txt
+++ b/glottisdale/requirements.txt
@@ -1,5 +1,6 @@
 openai-whisper>=20231117
 g2p_en>=2.1.0
+scipy>=1.11.0
 slack-sdk>=3.27.0
 requests>=2.31.0
 pytest>=8.0.0

--- a/glottisdale/tests/test_integration.py
+++ b/glottisdale/tests/test_integration.py
@@ -67,3 +67,97 @@ def test_full_pipeline_local_mode(mock_transcribe, tmp_path):
 
     # 6 syllables grouped into variable-length words — at least 2 words
     assert len(result.clips) >= 2
+
+
+@pytest.mark.integration
+@patch("glottisdale.align.transcribe")
+def test_audio_polish_integration(mock_transcribe, tmp_path):
+    """End-to-end test with audio polish features enabled."""
+    import subprocess
+
+    input_wav = tmp_path / "input.wav"
+    subprocess.run([
+        "ffmpeg", "-y", "-f", "lavfi",
+        "-i", "sine=frequency=200:duration=4",
+        "-ar", "16000", "-ac", "1",
+        str(input_wav),
+    ], capture_output=True, check=True)
+
+    mock_transcribe.return_value = {
+        "text": "hello beautiful world today",
+        "words": [
+            {"word": "hello", "start": 0.0, "end": 0.5},
+            {"word": "beautiful", "start": 0.6, "end": 1.3},
+            {"word": "world", "start": 1.8, "end": 2.3},
+            {"word": "today", "start": 2.8, "end": 3.5},
+        ],
+        "language": "en",
+    }
+
+    output_dir = tmp_path / "output"
+    result = process(
+        input_paths=[input_wav],
+        output_dir=output_dir,
+        target_duration=10.0,
+        seed=42,
+        noise_level_db=-40,
+        room_tone=True,
+        pitch_normalize=True,
+        pitch_range=5,
+        breaths=True,
+        breath_probability=1.0,
+        volume_normalize=True,
+        prosodic_dynamics=True,
+    )
+
+    assert result.concatenated.exists()
+    assert result.concatenated.stat().st_size > 0
+    from glottisdale.audio import get_duration
+    dur = get_duration(result.concatenated)
+    assert dur > 0
+
+
+@pytest.mark.integration
+@patch("glottisdale.align.transcribe")
+def test_audio_polish_all_disabled(mock_transcribe, tmp_path):
+    """Audio polish features can all be disabled."""
+    import subprocess
+
+    input_wav = tmp_path / "input.wav"
+    subprocess.run([
+        "ffmpeg", "-y", "-f", "lavfi",
+        "-i", "sine=frequency=440:duration=3",
+        "-ar", "16000", "-ac", "1",
+        str(input_wav),
+    ], capture_output=True, check=True)
+
+    mock_transcribe.return_value = {
+        "text": "hello world",
+        "words": [
+            {"word": "hello", "start": 0.0, "end": 0.8},
+            {"word": "world", "start": 1.0, "end": 2.0},
+        ],
+        "language": "en",
+    }
+
+    output_dir = tmp_path / "output"
+    result = process(
+        input_paths=[input_wav],
+        output_dir=output_dir,
+        target_duration=5.0,
+        crossfade_ms=0,
+        padding_ms=10,
+        phrase_pause="0",
+        sentence_pause="0",
+        word_crossfade_ms=0,
+        seed=42,
+        noise_level_db=0,
+        room_tone=False,
+        pitch_normalize=False,
+        breaths=False,
+        volume_normalize=False,
+        prosodic_dynamics=False,
+    )
+
+    assert result.concatenated.exists()
+    assert result.concatenated.stat().st_size > 0


### PR DESCRIPTION
## Summary
- Add `scipy` to `requirements.txt` and `pyproject.toml` — `analysis.py` imports `scipy.io.wavfile` at module level, was missing from CI causing `ModuleNotFoundError`
- Add audio polish integration tests that were lost during PR #21 merge
- Fix workflow default `target_duration` fallback from 10 to 30 seconds

## Test plan
- [x] 112 tests pass locally
- [ ] CI workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)