### PR TITLE
Add BFA forced aligner for phoneme-level timestamps

### DIFF
--- a/.github/workflows/glottisdale.yml
+++ b/.github/workflows/glottisdale.yml
@@ -36,16 +36,17 @@ jobs:
           path: |
             ~/.cache/whisper
             ~/.cache/torch
-          key: glottisdale-models-${{ inputs.whisper_model || 'base' }}
+            ~/.cache/bournemouth_aligner
+          key: glottisdale-models-bfa-${{ inputs.whisper_model || 'base' }}
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg espeak-ng
 
       - name: Install Python dependencies
         run: |
           pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r glottisdale/requirements.txt
-          pip install -e glottisdale/
+          pip install -e 'glottisdale/[bfa]'
           python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng')"
 
       - name: Run glottisdale
@@ -55,6 +56,7 @@ jobs:
           ARGS="--target-duration ${{ inputs.target_duration || '30' }}"
           ARGS="$ARGS --max-videos ${{ inputs.max_videos || '5' }}"
           ARGS="$ARGS --whisper-model ${{ inputs.whisper_model || 'base' }}"
+          ARGS="$ARGS --aligner auto"
           if [ -n "${{ inputs.seed }}" ]; then
             ARGS="$ARGS --seed ${{ inputs.seed }}"
           fi

--- a/glottisdale/pyproject.toml
+++ b/glottisdale/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 
 [project.optional-dependencies]
 slack = ["slack-sdk>=3.27.0", "requests>=2.31.0"]
+bfa = ["bournemouth-forced-aligner>=1.1.0"]
 dev = ["pytest>=8.0.0"]
 
 [project.scripts]

--- a/glottisdale/src/glottisdale/__init__.py
+++ b/glottisdale/src/glottisdale/__init__.py
@@ -203,8 +203,9 @@ def process(
     phrase_pause: str = "400-700",
     sentence_pause: str = "800-1200",
     word_crossfade_ms: float = 50,
-    aligner: str = "default",
+    aligner: str = "auto",
     whisper_model: str = "base",
+    bfa_device: str = "cpu",
     seed: int | None = None,
     # Audio polish params
     noise_level_db: float = -40,
@@ -235,7 +236,7 @@ def process(
     pps_min, pps_max = _parse_range(phrases_per_sentence)
     pp_min, pp_max = _parse_gap(phrase_pause)
     sp_min, sp_max = _parse_gap(sentence_pause)
-    alignment_engine = get_aligner(aligner, whisper_model=whisper_model)
+    alignment_engine = get_aligner(aligner, whisper_model=whisper_model, device=bfa_device)
 
     # Process each input file
     all_syllables: dict[str, list[Syllable]] = {}

--- a/glottisdale/src/glottisdale/align.py
+++ b/glottisdale/src/glottisdale/align.py
@@ -1,11 +1,15 @@
 """Aligner interface and backends."""
 
+import logging
+import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
 
 from glottisdale.types import Syllable
 from glottisdale.transcribe import transcribe
 from glottisdale.syllabify import syllabify_words
+
+logger = logging.getLogger(__name__)
 
 
 class Aligner(ABC):
@@ -30,7 +34,7 @@ class DefaultAligner(Aligner):
     syllable timing estimated by proportional distribution.
     """
 
-    def __init__(self, whisper_model: str = "base", language: str = "en"):
+    def __init__(self, whisper_model: str = "base", language: str = "en", **kwargs):
         self.whisper_model = whisper_model
         self.language = language
 
@@ -44,14 +48,60 @@ class DefaultAligner(Aligner):
         }
 
 
-# Registry of available backends
+def _get_bfa_class():
+    """Lazy import of BFAAligner to avoid hard dependency."""
+    from glottisdale.bfa import BFAAligner
+    return BFAAligner
+
+
+def _bfa_available() -> bool:
+    """Check if BFA and espeak-ng are both available."""
+    try:
+        import bournemouth_aligner  # noqa: F401
+    except ImportError:
+        return False
+    if shutil.which("espeak-ng") is None:
+        return False
+    return True
+
+
+# Registry of available backends (lazy import for BFA)
 _ALIGNERS = {
     "default": DefaultAligner,
+    "bfa": _get_bfa_class,
 }
 
 
 def get_aligner(name: str, **kwargs) -> Aligner:
-    """Get an aligner backend by name."""
+    """Get an aligner backend by name.
+
+    Modes:
+        "default" — Whisper + g2p_en + ARPABET proportional timing.
+        "bfa" — Whisper + BFA phoneme-level alignment (requires bournemouth-forced-aligner + espeak-ng).
+        "auto" — Tries BFA first, falls back to default if unavailable.
+    """
+    if name == "auto":
+        if _bfa_available():
+            logger.info("Auto-detected BFA + espeak-ng, using BFA aligner")
+            return _get_bfa_class()(**kwargs)
+        else:
+            logger.info("BFA not available, falling back to default (proportional) aligner")
+            return DefaultAligner(**kwargs)
+
     if name not in _ALIGNERS:
-        raise ValueError(f"Unknown aligner: {name!r}. Available: {list(_ALIGNERS.keys())}")
-    return _ALIGNERS[name](**kwargs)
+        raise ValueError(
+            f"Unknown aligner: {name!r}. Available: {list(_ALIGNERS.keys()) + ['auto']}"
+        )
+
+    factory = _ALIGNERS[name]
+    # BFA entry is a function returning the class (lazy import)
+    if name == "bfa":
+        try:
+            cls = factory()
+        except ImportError as e:
+            raise ImportError(
+                f"BFA aligner requires 'bournemouth-forced-aligner' package: {e}"
+            ) from e
+        return cls(**kwargs)
+
+    return factory(**kwargs)

--- a/glottisdale/src/glottisdale/bfa.py
+++ b/glottisdale/src/glottisdale/bfa.py
@@ -1,0 +1,217 @@
+"""BFA (Bournemouth Forced Aligner) backend for phoneme-level alignment."""
+
+import logging
+from pathlib import Path
+
+from glottisdale.align import Aligner
+from glottisdale.transcribe import transcribe
+from glottisdale.types import Phoneme, Syllable
+from glottisdale.syllabify_ipa import syllabify_ipa
+
+logger = logging.getLogger(__name__)
+
+
+class BFAAligner(Aligner):
+    """BFA phoneme-level forced aligner.
+
+    Uses Whisper for transcription (word-level timestamps), then BFA
+    for precise phoneme-level timestamps with pg16 group classifications.
+    Syllabification uses the IPA sonority-based syllabifier.
+    """
+
+    def __init__(
+        self,
+        whisper_model: str = "base",
+        language: str = "en",
+        device: str = "cpu",
+    ):
+        self.whisper_model = whisper_model
+        self.language = language
+        self.device = device
+        self._aligner = None
+
+    def _get_aligner(self):
+        """Lazy-init BFA aligner."""
+        if self._aligner is None:
+            from bournemouth_aligner import PhonemeTimestampAligner
+
+            self._aligner = PhonemeTimestampAligner(
+                preset="en-us",
+                device=self.device,
+            )
+        return self._aligner
+
+    def process(self, audio_path: Path) -> dict:
+        """Transcribe and align audio using Whisper + BFA.
+
+        Returns:
+            Dict with keys:
+                text: Full transcript
+                words: List of word dicts with timestamps
+                syllables: List of Syllable objects with real BFA timestamps
+        """
+        # Step 1: Whisper transcription for word boundaries
+        whisper_result = transcribe(
+            audio_path, model_name=self.whisper_model, language=self.language
+        )
+
+        # Step 2: BFA phoneme alignment
+        aligner = self._get_aligner()
+        audio_wav = aligner.load_audio(str(audio_path))
+
+        all_syllables = []
+        for word_idx, word_info in enumerate(whisper_result["words"]):
+            word_text = word_info["word"].strip()
+            if not word_text:
+                continue
+
+            try:
+                phonemes, pg16_groups = _align_word(
+                    aligner, audio_wav, word_text,
+                    word_info["start"], word_info["end"],
+                )
+            except Exception as e:
+                logger.debug(f"BFA failed for word '{word_text}': {e}")
+                continue
+
+            if not phonemes:
+                continue
+
+            syls = syllabify_ipa(
+                phonemes=phonemes,
+                pg16_groups=pg16_groups,
+                word=word_text,
+                word_index=word_idx,
+            )
+            all_syllables.extend(syls)
+
+        return {
+            "text": whisper_result["text"],
+            "words": whisper_result["words"],
+            "syllables": all_syllables,
+        }
+
+
+def _align_word(
+    aligner,
+    audio_wav,
+    word_text: str,
+    word_start: float,
+    word_end: float,
+) -> tuple[list[Phoneme], list[str]]:
+    """Run BFA alignment on a single word, returning Phoneme objects + pg16 groups.
+
+    Args:
+        aligner: PhonemeTimestampAligner instance.
+        audio_wav: Pre-loaded audio from aligner.load_audio().
+        word_text: The word to align.
+        word_start: Word start time from Whisper (seconds).
+        word_end: Word end time from Whisper (seconds).
+
+    Returns:
+        Tuple of (phoneme list, pg16 group list), parallel arrays.
+    """
+    result = aligner.process_sentence(
+        text=word_text,
+        audio=audio_wav,
+        do_groups=True,
+    )
+
+    phoneme_ts = result.get("phoneme_ts", [])
+    group_ts = result.get("group_ts", [])
+
+    phonemes = []
+    pg16_groups = []
+
+    for ph_info in phoneme_ts:
+        ipa_label = ph_info.get("ipa_label", ph_info.get("phoneme_label", ""))
+        start_ms = ph_info.get("start_ms", 0.0)
+        end_ms = ph_info.get("end_ms", 0.0)
+
+        # Convert ms to seconds, offset by word start
+        start_s = word_start + start_ms / 1000.0
+        end_s = word_start + end_ms / 1000.0
+
+        # Clamp to word boundaries
+        start_s = max(start_s, word_start)
+        end_s = min(end_s, word_end)
+
+        if end_s <= start_s:
+            continue
+
+        phonemes.append(Phoneme(
+            label=ipa_label,
+            start=round(start_s, 4),
+            end=round(end_s, 4),
+        ))
+
+        # Find pg16 group for this phoneme
+        pg16 = _find_pg16_group(ph_info, group_ts)
+        pg16_groups.append(pg16)
+
+    return phonemes, pg16_groups
+
+
+def _find_pg16_group(ph_info: dict, group_ts: list[dict]) -> str:
+    """Find the pg16 group classification for a phoneme.
+
+    BFA provides group_ts with timing and group labels. Match by
+    phoneme index or overlapping timing.
+    """
+    ph_idx = ph_info.get("index", ph_info.get("target_seq_idx", -1))
+
+    # Try matching by index in group_ts
+    for group in group_ts:
+        if group.get("index") == ph_idx or group.get("target_seq_idx") == ph_idx:
+            return group.get("pg16", group.get("group", "consonants"))
+
+    # Fallback: try matching by timing overlap
+    ph_start = ph_info.get("start_ms", 0)
+    ph_end = ph_info.get("end_ms", 0)
+    for group in group_ts:
+        g_start = group.get("start_ms", 0)
+        g_end = group.get("end_ms", 0)
+        if g_start <= ph_start and g_end >= ph_end:
+            return group.get("pg16", group.get("group", "consonants"))
+
+    # Last resort: infer from IPA label
+    return _infer_pg16_from_ipa(ph_info.get("ipa_label", ""))
+
+
+def _infer_pg16_from_ipa(ipa_label: str) -> str:
+    """Best-effort pg16 group inference from IPA label when BFA groups unavailable."""
+    if not ipa_label:
+        return "silence"
+
+    # Common vowel IPA symbols
+    vowels = set("aeiouɪɛæɑɒɔʊəɜɐʌ")
+    diphthong_starts = {"aɪ", "aʊ", "eɪ", "oʊ", "ɔɪ"}
+
+    if any(ipa_label.startswith(d) for d in diphthong_starts):
+        return "diphthongs"
+    if ipa_label[0] in vowels or ipa_label.rstrip("ːˑ") in vowels:
+        return "vowels"
+
+    # Common consonant groups
+    stops = set("pbtdkgʔ")
+    nasals = set("mnɲŋɴ")
+    fricatives = set("fvθðszʃʒçxɣhɦ")
+    laterals = set("lɫɬɮ")
+    rhotics = {"r", "ɹ", "ɾ", "ɽ", "ʁ", "ʀ"}
+    glides = {"j", "w", "ɥ"}
+
+    ch = ipa_label[0]
+    if ipa_label in rhotics or ch in {"ɹ", "ɾ", "r"}:
+        return "rhotics"
+    if ch in stops:
+        return "voiced_stops"
+    if ch in nasals:
+        return "nasals"
+    if ch in fricatives:
+        return "voiceless_fricatives"
+    if ch in laterals:
+        return "laterals"
+    if ch in glides or ipa_label in glides:
+        return "glides"
+
+    return "consonants"

--- a/glottisdale/src/glottisdale/cli.py
+++ b/glottisdale/src/glottisdale/cli.py
@@ -47,8 +47,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--whisper-model", default="base",
                         choices=["tiny", "base", "small", "medium"],
                         help="Whisper model size (default: base)")
-    parser.add_argument("--aligner", default="default",
-                        help="Alignment backend (default: default)")
+    parser.add_argument("--aligner", default="auto",
+                        choices=["auto", "default", "bfa"],
+                        help="Alignment backend: auto (try BFA, fallback to default), "
+                             "default (proportional), bfa (forced alignment) (default: auto)")
+    parser.add_argument("--bfa-device", default="cpu",
+                        choices=["cpu", "cuda"],
+                        help="Device for BFA model inference (default: cpu)")
     parser.add_argument("--seed", type=int, default=None,
                         help="RNG seed for reproducible output")
 
@@ -126,6 +131,7 @@ def main(argv: list[str] | None = None) -> None:
             word_crossfade_ms=args.word_crossfade,
             aligner=args.aligner,
             whisper_model=args.whisper_model,
+            bfa_device=args.bfa_device,
             seed=args.seed,
             noise_level_db=args.noise_level,
             room_tone=args.room_tone,
@@ -192,6 +198,7 @@ def main(argv: list[str] | None = None) -> None:
                 word_crossfade_ms=args.word_crossfade,
                 aligner=args.aligner,
                 whisper_model=args.whisper_model,
+                bfa_device=args.bfa_device,
                 seed=args.seed,
                 noise_level_db=args.noise_level,
                 room_tone=args.room_tone,

--- a/glottisdale/src/glottisdale/phonotactics.py
+++ b/glottisdale/src/glottisdale/phonotactics.py
@@ -34,12 +34,59 @@ for p in ("W", "Y"):
 # Illegal English onsets (these sounds cannot start a word/syllable)
 _ILLEGAL_ONSETS = {"NG", "ZH"}
 
+# IPA sonority mapping for BFA phonemes
+_IPA_VOWELS = set("aeiouɪɛæɑɒɔʊəɜɐʌ")
+_IPA_STOPS = set("pbtdkgʔ")
+_IPA_NASALS = set("mnɲŋɴ")
+_IPA_FRICATIVES = set("fvθðszʃʒçxɣhɦ")
+_IPA_LATERALS = set("lɫɬɮ")
+_IPA_RHOTICS = {"r", "ɹ", "ɾ", "ɽ", "ʁ", "ʀ"}
+_IPA_GLIDES = {"j", "w", "ɥ"}
+_IPA_DIPHTHONG_STARTS = {"aɪ", "aʊ", "eɪ", "oʊ", "ɔɪ"}
+
+# IPA illegal onsets (velar nasal can't start English syllables)
+_IPA_ILLEGAL_ONSETS = {"ŋ"}
+
+
+def _is_ipa(label: str) -> bool:
+    """Heuristic: IPA labels use lowercase/Unicode, ARPABET uses uppercase ASCII."""
+    if not label:
+        return False
+    return label[0].islower() or not label[0].isascii()
+
+
+def _ipa_sonority(label: str) -> int:
+    """Return sonority value for an IPA phoneme label."""
+    if not label:
+        return 0
+    if any(label.startswith(d) for d in _IPA_DIPHTHONG_STARTS):
+        return 7
+    if label[0] in _IPA_VOWELS or label.rstrip("ːˑ") in _IPA_VOWELS:
+        return 7
+    if label in _IPA_GLIDES or label[0] in {"j", "w", "ɥ"}:
+        return 6
+    if label in _IPA_RHOTICS or label[0] in {"ɹ", "ɾ", "r"}:
+        return 5
+    if label[0] in _IPA_LATERALS:
+        return 5
+    if label[0] in _IPA_NASALS:
+        return 4
+    if label[0] in _IPA_FRICATIVES:
+        return 3
+    if label[0] in _IPA_STOPS:
+        return 1
+    return 0
+
 
 def sonority(label: str) -> int:
-    """Return sonority value for an ARPABET phoneme label.
+    """Return sonority value for a phoneme label (ARPABET or IPA).
 
-    Strips stress digits (e.g. 'AH0' -> vowel). Returns 0 for unknown.
+    Strips stress digits for ARPABET (e.g. 'AH0' -> vowel). Returns 0 for unknown.
     """
+    if _is_ipa(label):
+        return _ipa_sonority(label)
+
+    # ARPABET path
     # Strip trailing stress digits for vowel lookup
     base = label.rstrip("012")
     if base in _SONORITY:
@@ -69,7 +116,7 @@ def score_junction(syl_a: Syllable, syl_b: Syllable) -> int:
 
     # Illegal onset penalty
     base_first = first_phone.rstrip("012")
-    if base_first in _ILLEGAL_ONSETS:
+    if base_first in _ILLEGAL_ONSETS or first_phone in _IPA_ILLEGAL_ONSETS:
         score -= 2
 
     # Hiatus penalty (vowel-vowel boundary)

--- a/glottisdale/src/glottisdale/syllabify_ipa.py
+++ b/glottisdale/src/glottisdale/syllabify_ipa.py
@@ -1,0 +1,215 @@
+"""IPA sonority-based syllabifier for BFA phoneme output.
+
+Uses BFA's pg16 phoneme group classifications to determine sonority,
+then applies Maximum Onset Principle to find syllable boundaries.
+"""
+
+from glottisdale.types import Phoneme, Syllable
+
+
+# Map BFA pg16 groups to sonority levels (higher = more sonorous)
+_PG16_SONORITY = {
+    "voiced_stops": 0,
+    "voiceless_stops": 0,  # not in pg16 but handle if seen
+    "affricates": 1,
+    "voiceless_fricatives": 2,
+    "voiced_fricatives": 2,
+    "nasals": 3,
+    "laterals": 4,
+    "rhotics": 4,
+    "approximants": 5,
+    "glides": 5,
+    "central_vowels": 6,
+    "front_vowels": 6,
+    "back_vowels": 6,
+    "diphthongs": 6,
+    "vowels": 6,
+    "consonants": 1,  # generic fallback for consonant group
+    "silence": -1,
+}
+
+
+def pg16_sonority(pg16_group: str) -> int:
+    """Return sonority level for a BFA pg16 phoneme group.
+
+    Returns -1 for silence, 0-6 for consonants-to-vowels.
+    """
+    return _PG16_SONORITY.get(pg16_group, 1)
+
+
+def _is_vowel(pg16_group: str) -> bool:
+    """Check if a pg16 group represents a vowel/nucleus."""
+    return pg16_group in (
+        "central_vowels", "front_vowels", "back_vowels",
+        "diphthongs", "vowels",
+    )
+
+
+def syllabify_ipa(
+    phonemes: list[Phoneme],
+    pg16_groups: list[str],
+    word: str,
+    word_index: int,
+) -> list[Syllable]:
+    """Syllabify IPA phonemes using sonority sequencing + Maximum Onset Principle.
+
+    Args:
+        phonemes: Phoneme objects with real BFA timestamps.
+        pg16_groups: BFA pg16 group label for each phoneme (parallel list).
+        word: The parent word text.
+        word_index: Position in transcript.
+
+    Returns:
+        List of Syllable objects with real timestamps from BFA.
+    """
+    if not phonemes:
+        return []
+
+    if len(phonemes) != len(pg16_groups):
+        raise ValueError(
+            f"phonemes ({len(phonemes)}) and pg16_groups ({len(pg16_groups)}) "
+            f"must have same length"
+        )
+
+    # Filter out silence phonemes
+    filtered = [
+        (ph, pg) for ph, pg in zip(phonemes, pg16_groups)
+        if pg != "silence"
+    ]
+    if not filtered:
+        return []
+
+    phonemes_f, groups_f = zip(*filtered)
+    phonemes_f = list(phonemes_f)
+    groups_f = list(groups_f)
+
+    # Find vowel nuclei indices
+    nuclei_indices = [i for i, g in enumerate(groups_f) if _is_vowel(g)]
+
+    # No vowels: treat entire sequence as one syllable
+    if not nuclei_indices:
+        return [Syllable(
+            phonemes=phonemes_f,
+            start=phonemes_f[0].start,
+            end=phonemes_f[-1].end,
+            word=word,
+            word_index=word_index,
+        )]
+
+    # Find syllable boundaries using Maximum Onset Principle
+    # Each nucleus gets surrounding consonants; maximize onset of following syllable
+    boundaries = _find_boundaries(phonemes_f, groups_f, nuclei_indices)
+
+    # Build syllables from boundaries
+    syllables = []
+    for start_idx, end_idx in boundaries:
+        syl_phones = phonemes_f[start_idx:end_idx]
+        if syl_phones:
+            syllables.append(Syllable(
+                phonemes=syl_phones,
+                start=syl_phones[0].start,
+                end=syl_phones[-1].end,
+                word=word,
+                word_index=word_index,
+            ))
+
+    return syllables
+
+
+def _find_boundaries(
+    phonemes: list[Phoneme],
+    groups: list[str],
+    nuclei_indices: list[int],
+) -> list[tuple[int, int]]:
+    """Find syllable boundary indices using Maximum Onset Principle.
+
+    For each pair of adjacent nuclei, find the optimal split point
+    in the consonant cluster between them that maximizes the onset
+    of the following syllable while maintaining valid sonority rise.
+
+    Returns list of (start_idx, end_idx) tuples (exclusive end).
+    """
+    n = len(phonemes)
+    boundaries: list[tuple[int, int]] = []
+
+    for syl_i in range(len(nuclei_indices)):
+        nuc = nuclei_indices[syl_i]
+
+        # Start of this syllable
+        if syl_i == 0:
+            syl_start = 0
+        else:
+            # Already set by previous iteration's split
+            syl_start = boundaries[-1][1]
+
+        # End of this syllable
+        if syl_i == len(nuclei_indices) - 1:
+            # Last syllable takes everything to the end
+            syl_end = n
+        else:
+            # Find split point in consonant cluster between this and next nucleus
+            next_nuc = nuclei_indices[syl_i + 1]
+            syl_end = _split_cluster(groups, nuc, next_nuc)
+
+        boundaries.append((syl_start, syl_end))
+
+    return boundaries
+
+
+def _split_cluster(
+    groups: list[str],
+    nuc_a: int,
+    nuc_b: int,
+) -> int:
+    """Find split point between two nuclei using Maximum Onset Principle.
+
+    Consonants between nuc_a and nuc_b: maximize onset (give as many
+    as possible to the following syllable) while ensuring sonority
+    rises toward the nucleus.
+
+    Returns the index where the next syllable should start.
+    """
+    # Consonant cluster is groups[nuc_a+1 : nuc_b]
+    cluster_start = nuc_a + 1
+    cluster_end = nuc_b
+
+    if cluster_start >= cluster_end:
+        # No consonants between nuclei — split at nuc_b
+        return nuc_b
+
+    # Maximum Onset Principle: start with all consonants as onset of next syllable,
+    # then move consonants to coda if they violate sonority sequencing.
+    # Valid onset: sonority should rise toward the nucleus.
+    cluster_len = cluster_end - cluster_start
+
+    # Try giving all consonants to onset (maximum onset)
+    # Then check if sonority rises — if not, peel off from the left
+    for split in range(cluster_start, cluster_end + 1):
+        # split = start of next syllable's onset
+        onset = groups[split:cluster_end]
+        if not onset:
+            # All consonants go to coda
+            return cluster_end
+
+        if _valid_onset(onset):
+            return split
+
+    # Fallback: split in the middle
+    return cluster_start + cluster_len // 2
+
+
+def _valid_onset(onset_groups: list[str]) -> bool:
+    """Check if a consonant sequence forms a valid onset (sonority rises).
+
+    A valid onset has non-decreasing sonority leading into the nucleus.
+    Single consonants are always valid. Empty onsets are valid.
+    """
+    if len(onset_groups) <= 1:
+        return True
+
+    sonorities = [pg16_sonority(g) for g in onset_groups]
+    # Sonority should generally rise (or stay level) toward nucleus
+    for i in range(len(sonorities) - 1):
+        if sonorities[i] > sonorities[i + 1]:
+            return False
+    return True

--- a/glottisdale/tests/test_align.py
+++ b/glottisdale/tests/test_align.py
@@ -1,9 +1,11 @@
 """Tests for aligner interface."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
-from glottisdale.align import get_aligner, DefaultAligner
+import pytest
+
+from glottisdale.align import get_aligner, DefaultAligner, _bfa_available
 from glottisdale.types import Syllable
 
 
@@ -13,9 +15,44 @@ def test_get_aligner_default():
 
 
 def test_get_aligner_unknown():
-    import pytest
     with pytest.raises(ValueError, match="Unknown aligner"):
         get_aligner("nonexistent")
+
+
+def test_get_aligner_auto_falls_back():
+    """Auto mode should fall back to DefaultAligner when BFA not installed."""
+    with patch("glottisdale.align._bfa_available", return_value=False):
+        aligner = get_aligner("auto")
+        assert isinstance(aligner, DefaultAligner)
+
+
+def test_get_aligner_auto_uses_bfa():
+    """Auto mode should use BFA when available."""
+    mock_bfa_cls = MagicMock()
+    with patch("glottisdale.align._bfa_available", return_value=True), \
+         patch("glottisdale.align._get_bfa_class", return_value=mock_bfa_cls):
+        get_aligner("auto")
+        mock_bfa_cls.assert_called_once()
+
+
+def test_get_aligner_bfa_lazy_import():
+    """BFA mode should lazy-import and raise clear error if not installed."""
+    # Patch the dict entry to simulate ImportError from lazy import
+    original = get_aligner.__module__
+    import glottisdale.align as align_mod
+    old_factory = align_mod._ALIGNERS["bfa"]
+    align_mod._ALIGNERS["bfa"] = lambda: (_ for _ in ()).throw(ImportError("no bfa"))
+    try:
+        with pytest.raises(ImportError, match="bournemouth-forced-aligner"):
+            get_aligner("bfa")
+    finally:
+        align_mod._ALIGNERS["bfa"] = old_factory
+
+
+def test_default_aligner_accepts_extra_kwargs():
+    """DefaultAligner should accept and ignore extra kwargs (e.g. device)."""
+    aligner = DefaultAligner(whisper_model="base", device="cpu")
+    assert aligner.whisper_model == "base"
 
 
 @patch("glottisdale.align.transcribe")

--- a/glottisdale/tests/test_bfa.py
+++ b/glottisdale/tests/test_bfa.py
@@ -1,0 +1,305 @@
+"""Tests for BFA aligner backend."""
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from glottisdale.types import Phoneme, Syllable
+from glottisdale.bfa import BFAAligner, _align_word, _find_pg16_group, _infer_pg16_from_ipa
+
+
+def _mock_bfa_phoneme(ipa_label, start_ms, end_ms, index, confidence=0.99):
+    """Create a mock BFA phoneme timestamp entry."""
+    return {
+        "phoneme_label": ipa_label,
+        "ipa_label": ipa_label,
+        "start_ms": start_ms,
+        "end_ms": end_ms,
+        "confidence": confidence,
+        "index": index,
+        "target_seq_idx": index,
+        "is_estimated": False,
+    }
+
+
+def _mock_bfa_group(pg16, start_ms, end_ms, index):
+    """Create a mock BFA group_ts entry."""
+    return {
+        "pg16": pg16,
+        "start_ms": start_ms,
+        "end_ms": end_ms,
+        "index": index,
+        "target_seq_idx": index,
+    }
+
+
+class TestAlignWord:
+    def test_basic_word_alignment(self):
+        """Test that _align_word converts BFA output to Phoneme objects."""
+        mock_aligner = MagicMock()
+        mock_aligner.process_sentence.return_value = {
+            "phoneme_ts": [
+                _mock_bfa_phoneme("k", 0.0, 50.0, 0),
+                _mock_bfa_phoneme("æ", 50.0, 150.0, 1),
+                _mock_bfa_phoneme("t", 150.0, 200.0, 2),
+            ],
+            "group_ts": [
+                _mock_bfa_group("voiced_stops", 0.0, 50.0, 0),
+                _mock_bfa_group("front_vowels", 50.0, 150.0, 1),
+                _mock_bfa_group("voiced_stops", 150.0, 200.0, 2),
+            ],
+        }
+
+        phonemes, groups = _align_word(
+            mock_aligner, MagicMock(), "cat",
+            word_start=1.0, word_end=1.5,
+        )
+
+        assert len(phonemes) == 3
+        assert len(groups) == 3
+        # Times should be offset by word_start (1.0s) and converted from ms
+        assert phonemes[0].label == "k"
+        assert phonemes[0].start == 1.0  # 1.0 + 0.0/1000
+        assert phonemes[0].end == 1.05   # 1.0 + 50.0/1000
+        assert phonemes[1].label == "æ"
+        assert groups == ["voiced_stops", "front_vowels", "voiced_stops"]
+
+    def test_timestamps_clamped_to_word_bounds(self):
+        """Phoneme timestamps should not exceed word boundaries."""
+        mock_aligner = MagicMock()
+        mock_aligner.process_sentence.return_value = {
+            "phoneme_ts": [
+                _mock_bfa_phoneme("k", 0.0, 500.0, 0),  # extends past word end
+            ],
+            "group_ts": [
+                _mock_bfa_group("voiced_stops", 0.0, 500.0, 0),
+            ],
+        }
+
+        phonemes, groups = _align_word(
+            mock_aligner, MagicMock(), "k",
+            word_start=1.0, word_end=1.2,
+        )
+
+        assert len(phonemes) == 1
+        assert phonemes[0].start == 1.0
+        assert phonemes[0].end == 1.2  # clamped to word_end
+
+    def test_zero_duration_phonemes_skipped(self):
+        """Phonemes with zero/negative duration after clamping should be dropped."""
+        mock_aligner = MagicMock()
+        mock_aligner.process_sentence.return_value = {
+            "phoneme_ts": [
+                _mock_bfa_phoneme("k", 300.0, 300.0, 0),  # zero duration
+                _mock_bfa_phoneme("æ", 50.0, 150.0, 1),
+            ],
+            "group_ts": [
+                _mock_bfa_group("voiced_stops", 300.0, 300.0, 0),
+                _mock_bfa_group("front_vowels", 50.0, 150.0, 1),
+            ],
+        }
+
+        phonemes, groups = _align_word(
+            mock_aligner, MagicMock(), "ka",
+            word_start=1.0, word_end=1.5,
+        )
+
+        assert len(phonemes) == 1
+        assert phonemes[0].label == "æ"
+
+    def test_process_sentence_called_correctly(self):
+        """Verify BFA is called with correct parameters."""
+        mock_aligner = MagicMock()
+        mock_aligner.process_sentence.return_value = {
+            "phoneme_ts": [],
+            "group_ts": [],
+        }
+        mock_audio = MagicMock()
+
+        _align_word(mock_aligner, mock_audio, "hello", 0.0, 0.5)
+
+        mock_aligner.process_sentence.assert_called_once_with(
+            text="hello",
+            audio=mock_audio,
+            do_groups=True,
+        )
+
+
+class TestFindPg16Group:
+    def test_match_by_index(self):
+        ph = {"index": 2, "start_ms": 100, "end_ms": 200}
+        groups = [
+            {"index": 0, "pg16": "voiced_stops"},
+            {"index": 1, "pg16": "front_vowels"},
+            {"index": 2, "pg16": "nasals"},
+        ]
+        assert _find_pg16_group(ph, groups) == "nasals"
+
+    def test_match_by_timing(self):
+        ph = {"index": 99, "start_ms": 100, "end_ms": 200, "ipa_label": "n"}
+        groups = [
+            {"start_ms": 0, "end_ms": 100, "pg16": "voiced_stops"},
+            {"start_ms": 100, "end_ms": 200, "pg16": "nasals"},
+        ]
+        assert _find_pg16_group(ph, groups) == "nasals"
+
+    def test_fallback_to_ipa_inference(self):
+        ph = {"index": 99, "start_ms": 999, "end_ms": 1000, "ipa_label": "n"}
+        groups = []  # no groups available
+        result = _find_pg16_group(ph, groups)
+        assert result == "nasals"
+
+
+class TestInferPg16FromIpa:
+    def test_vowels(self):
+        assert _infer_pg16_from_ipa("ə") == "vowels"
+        assert _infer_pg16_from_ipa("æ") == "vowels"
+        assert _infer_pg16_from_ipa("iː") == "vowels"
+
+    def test_diphthongs(self):
+        assert _infer_pg16_from_ipa("aɪ") == "diphthongs"
+        assert _infer_pg16_from_ipa("oʊ") == "diphthongs"
+        assert _infer_pg16_from_ipa("eɪ") == "diphthongs"
+
+    def test_stops(self):
+        assert _infer_pg16_from_ipa("p") == "voiced_stops"
+        assert _infer_pg16_from_ipa("b") == "voiced_stops"
+        assert _infer_pg16_from_ipa("t") == "voiced_stops"
+
+    def test_nasals(self):
+        assert _infer_pg16_from_ipa("m") == "nasals"
+        assert _infer_pg16_from_ipa("n") == "nasals"
+        assert _infer_pg16_from_ipa("ŋ") == "nasals"
+
+    def test_fricatives(self):
+        assert _infer_pg16_from_ipa("f") == "voiceless_fricatives"
+        assert _infer_pg16_from_ipa("s") == "voiceless_fricatives"
+
+    def test_laterals(self):
+        assert _infer_pg16_from_ipa("l") == "laterals"
+
+    def test_rhotics(self):
+        assert _infer_pg16_from_ipa("ɹ") == "rhotics"
+        assert _infer_pg16_from_ipa("r") == "rhotics"
+
+    def test_glides(self):
+        assert _infer_pg16_from_ipa("j") == "glides"
+        assert _infer_pg16_from_ipa("w") == "glides"
+
+    def test_empty_is_silence(self):
+        assert _infer_pg16_from_ipa("") == "silence"
+
+
+class TestBFAAlignerProcess:
+    @patch("glottisdale.bfa.transcribe")
+    def test_full_pipeline(self, mock_transcribe):
+        """Test the full BFA aligner pipeline with mocked dependencies."""
+        mock_transcribe.return_value = {
+            "text": "hello world",
+            "words": [
+                {"word": "hello", "start": 0.0, "end": 0.4},
+                {"word": "world", "start": 0.5, "end": 0.9},
+            ],
+            "language": "en",
+        }
+
+        # Mock the BFA aligner
+        mock_bfa = MagicMock()
+
+        def mock_process_sentence(text, audio, do_groups=False):
+            if text == "hello":
+                return {
+                    "phoneme_ts": [
+                        _mock_bfa_phoneme("h", 0.0, 40.0, 0),
+                        _mock_bfa_phoneme("ɛ", 40.0, 120.0, 1),
+                        _mock_bfa_phoneme("l", 120.0, 180.0, 2),
+                        _mock_bfa_phoneme("oʊ", 180.0, 300.0, 3),
+                    ],
+                    "group_ts": [
+                        _mock_bfa_group("voiceless_fricatives", 0.0, 40.0, 0),
+                        _mock_bfa_group("front_vowels", 40.0, 120.0, 1),
+                        _mock_bfa_group("laterals", 120.0, 180.0, 2),
+                        _mock_bfa_group("diphthongs", 180.0, 300.0, 3),
+                    ],
+                }
+            elif text == "world":
+                return {
+                    "phoneme_ts": [
+                        _mock_bfa_phoneme("w", 0.0, 50.0, 0),
+                        _mock_bfa_phoneme("ɜː", 50.0, 200.0, 1),
+                        _mock_bfa_phoneme("l", 200.0, 280.0, 2),
+                        _mock_bfa_phoneme("d", 280.0, 350.0, 3),
+                    ],
+                    "group_ts": [
+                        _mock_bfa_group("glides", 0.0, 50.0, 0),
+                        _mock_bfa_group("central_vowels", 50.0, 200.0, 1),
+                        _mock_bfa_group("laterals", 200.0, 280.0, 2),
+                        _mock_bfa_group("voiced_stops", 280.0, 350.0, 3),
+                    ],
+                }
+            return {"phoneme_ts": [], "group_ts": []}
+
+        mock_bfa.process_sentence = mock_process_sentence
+        mock_bfa.load_audio.return_value = MagicMock()
+
+        aligner = BFAAligner(whisper_model="base", device="cpu")
+        aligner._aligner = mock_bfa
+
+        result = aligner.process(Path("fake.wav"))
+
+        assert result["text"] == "hello world"
+        assert len(result["words"]) == 2
+        syllables = result["syllables"]
+        assert len(syllables) >= 2  # "hello" has 2 syllables, "world" has 1
+        assert all(isinstance(s, Syllable) for s in syllables)
+
+        # Check hello syllables have real BFA timestamps (not proportional)
+        hello_syls = [s for s in syllables if s.word == "hello"]
+        assert len(hello_syls) == 2
+        # First hello syllable starts at 0.0 (word_start + 0ms)
+        assert hello_syls[0].start == 0.0
+
+    @patch("glottisdale.bfa.transcribe")
+    def test_bfa_failure_graceful(self, mock_transcribe):
+        """If BFA fails for a word, it should be skipped (not crash)."""
+        mock_transcribe.return_value = {
+            "text": "hello",
+            "words": [
+                {"word": "hello", "start": 0.0, "end": 0.4},
+            ],
+            "language": "en",
+        }
+
+        mock_bfa = MagicMock()
+        mock_bfa.process_sentence.side_effect = RuntimeError("BFA crashed")
+        mock_bfa.load_audio.return_value = MagicMock()
+
+        aligner = BFAAligner()
+        aligner._aligner = mock_bfa
+
+        result = aligner.process(Path("fake.wav"))
+
+        assert result["text"] == "hello"
+        assert result["syllables"] == []  # graceful fallback
+
+    @patch("glottisdale.bfa.transcribe")
+    def test_empty_words_skipped(self, mock_transcribe):
+        """Words with only whitespace should be skipped."""
+        mock_transcribe.return_value = {
+            "text": "  ",
+            "words": [
+                {"word": "  ", "start": 0.0, "end": 0.1},
+            ],
+            "language": "en",
+        }
+
+        mock_bfa = MagicMock()
+        mock_bfa.load_audio.return_value = MagicMock()
+
+        aligner = BFAAligner()
+        aligner._aligner = mock_bfa
+
+        result = aligner.process(Path("fake.wav"))
+        assert result["syllables"] == []
+        mock_bfa.process_sentence.assert_not_called()

--- a/glottisdale/tests/test_cli.py
+++ b/glottisdale/tests/test_cli.py
@@ -25,7 +25,8 @@ def test_parse_defaults():
     assert args.phrases_per_sentence == "2-3"
     assert args.word_crossfade == 50
     assert args.whisper_model == "base"
-    assert args.aligner == "default"
+    assert args.aligner == "auto"
+    assert args.bfa_device == "cpu"
     assert args.seed is None
 
 

--- a/glottisdale/tests/test_syllabify_ipa.py
+++ b/glottisdale/tests/test_syllabify_ipa.py
@@ -1,0 +1,265 @@
+"""Tests for IPA sonority-based syllabifier."""
+
+import pytest
+
+from glottisdale.types import Phoneme, Syllable
+from glottisdale.syllabify_ipa import (
+    pg16_sonority,
+    syllabify_ipa,
+    _is_vowel,
+    _valid_onset,
+)
+
+
+def _ph(label: str, start: float, end: float) -> Phoneme:
+    """Helper to create a Phoneme."""
+    return Phoneme(label=label, start=start, end=end)
+
+
+class TestPg16Sonority:
+    def test_stops_lowest(self):
+        assert pg16_sonority("voiced_stops") == 0
+
+    def test_affricates(self):
+        assert pg16_sonority("affricates") == 1
+
+    def test_fricatives(self):
+        assert pg16_sonority("voiceless_fricatives") == 2
+        assert pg16_sonority("voiced_fricatives") == 2
+
+    def test_nasals(self):
+        assert pg16_sonority("nasals") == 3
+
+    def test_laterals_and_rhotics(self):
+        assert pg16_sonority("laterals") == 4
+        assert pg16_sonority("rhotics") == 4
+
+    def test_glides_and_approximants(self):
+        assert pg16_sonority("glides") == 5
+        assert pg16_sonority("approximants") == 5
+
+    def test_vowels_highest(self):
+        assert pg16_sonority("central_vowels") == 6
+        assert pg16_sonority("front_vowels") == 6
+        assert pg16_sonority("back_vowels") == 6
+        assert pg16_sonority("diphthongs") == 6
+        assert pg16_sonority("vowels") == 6
+
+    def test_silence(self):
+        assert pg16_sonority("silence") == -1
+
+    def test_unknown_defaults_to_1(self):
+        assert pg16_sonority("unknown_group") == 1
+
+    def test_sonority_ordering(self):
+        """Verify stops < fricatives < nasals < liquids < glides < vowels."""
+        assert pg16_sonority("voiced_stops") < pg16_sonority("voiceless_fricatives")
+        assert pg16_sonority("voiceless_fricatives") < pg16_sonority("nasals")
+        assert pg16_sonority("nasals") < pg16_sonority("laterals")
+        assert pg16_sonority("laterals") < pg16_sonority("glides")
+        assert pg16_sonority("glides") < pg16_sonority("vowels")
+
+
+class TestIsVowel:
+    def test_vowel_groups(self):
+        assert _is_vowel("central_vowels")
+        assert _is_vowel("front_vowels")
+        assert _is_vowel("back_vowels")
+        assert _is_vowel("diphthongs")
+        assert _is_vowel("vowels")
+
+    def test_non_vowel_groups(self):
+        assert not _is_vowel("voiced_stops")
+        assert not _is_vowel("nasals")
+        assert not _is_vowel("laterals")
+        assert not _is_vowel("silence")
+
+
+class TestValidOnset:
+    def test_empty_valid(self):
+        assert _valid_onset([])
+
+    def test_single_consonant_valid(self):
+        assert _valid_onset(["voiced_stops"])
+
+    def test_rising_sonority_valid(self):
+        # stop + liquid = valid (e.g., "pl", "br")
+        assert _valid_onset(["voiced_stops", "laterals"])
+
+    def test_falling_sonority_invalid(self):
+        # liquid + stop = invalid onset
+        assert not _valid_onset(["laterals", "voiced_stops"])
+
+    def test_equal_sonority_valid(self):
+        # same level = valid
+        assert _valid_onset(["laterals", "rhotics"])
+
+
+class TestSyllabifyIpa:
+    def test_single_syllable_cvc(self):
+        """'cat' = k æ t → 1 syllable."""
+        phonemes = [
+            _ph("k", 0.0, 0.1),
+            _ph("æ", 0.1, 0.25),
+            _ph("t", 0.25, 0.35),
+        ]
+        groups = ["voiced_stops", "front_vowels", "voiced_stops"]
+        syls = syllabify_ipa(phonemes, groups, "cat", 0)
+        assert len(syls) == 1
+        assert syls[0].start == 0.0
+        assert syls[0].end == 0.35
+        assert len(syls[0].phonemes) == 3
+
+    def test_two_syllable_word(self):
+        """'butter' = b ʌ t ə ɹ → 2 syllables (bʌt.əɹ)."""
+        phonemes = [
+            _ph("b", 0.0, 0.05),
+            _ph("ʌ", 0.05, 0.15),
+            _ph("t", 0.15, 0.22),
+            _ph("ə", 0.22, 0.30),
+            _ph("ɹ", 0.30, 0.38),
+        ]
+        groups = [
+            "voiced_stops", "central_vowels", "voiced_stops",
+            "central_vowels", "rhotics",
+        ]
+        syls = syllabify_ipa(phonemes, groups, "butter", 0)
+        assert len(syls) == 2
+        # First syllable should start at 0.0
+        assert syls[0].start == 0.0
+        # Second syllable should end at 0.38
+        assert syls[1].end == 0.38
+
+    def test_three_syllable_word(self):
+        """'beautiful' = b j uː t ɪ f ə l → 3 syllables."""
+        phonemes = [
+            _ph("b", 0.0, 0.04),
+            _ph("j", 0.04, 0.08),
+            _ph("uː", 0.08, 0.18),
+            _ph("t", 0.18, 0.24),
+            _ph("ɪ", 0.24, 0.32),
+            _ph("f", 0.32, 0.38),
+            _ph("ə", 0.38, 0.44),
+            _ph("l", 0.44, 0.50),
+        ]
+        groups = [
+            "voiced_stops", "glides", "back_vowels",
+            "voiced_stops", "front_vowels",
+            "voiceless_fricatives", "central_vowels", "laterals",
+        ]
+        syls = syllabify_ipa(phonemes, groups, "beautiful", 0)
+        assert len(syls) == 3
+
+    def test_single_vowel_word(self):
+        """'a' = ə → 1 syllable."""
+        phonemes = [_ph("ə", 0.0, 0.1)]
+        groups = ["central_vowels"]
+        syls = syllabify_ipa(phonemes, groups, "a", 0)
+        assert len(syls) == 1
+        assert syls[0].phonemes == phonemes
+
+    def test_consonant_only_word(self):
+        """All consonants → 1 syllable (fallback)."""
+        phonemes = [
+            _ph("s", 0.0, 0.1),
+            _ph("t", 0.1, 0.2),
+        ]
+        groups = ["voiceless_fricatives", "voiced_stops"]
+        syls = syllabify_ipa(phonemes, groups, "st", 0)
+        assert len(syls) == 1
+        assert len(syls[0].phonemes) == 2
+
+    def test_consonant_cluster_onset(self):
+        """'string' = s t ɹ ɪ ŋ → 1 syllable (str- onset)."""
+        phonemes = [
+            _ph("s", 0.0, 0.05),
+            _ph("t", 0.05, 0.10),
+            _ph("ɹ", 0.10, 0.15),
+            _ph("ɪ", 0.15, 0.25),
+            _ph("ŋ", 0.25, 0.33),
+        ]
+        groups = [
+            "voiceless_fricatives", "voiced_stops", "rhotics",
+            "front_vowels", "nasals",
+        ]
+        syls = syllabify_ipa(phonemes, groups, "string", 0)
+        assert len(syls) == 1
+
+    def test_silence_phonemes_filtered(self):
+        """Silence phonemes should be excluded."""
+        phonemes = [
+            _ph("", 0.0, 0.05),
+            _ph("k", 0.05, 0.1),
+            _ph("æ", 0.1, 0.2),
+            _ph("t", 0.2, 0.3),
+            _ph("", 0.3, 0.35),
+        ]
+        groups = ["silence", "voiced_stops", "front_vowels", "voiced_stops", "silence"]
+        syls = syllabify_ipa(phonemes, groups, "cat", 0)
+        assert len(syls) == 1
+        # Should only have 3 non-silence phonemes
+        assert len(syls[0].phonemes) == 3
+
+    def test_real_timestamps_preserved(self):
+        """BFA timestamps should pass through unchanged (not proportional)."""
+        phonemes = [
+            _ph("h", 0.033, 0.067),
+            _ph("ɛ", 0.067, 0.150),
+            _ph("l", 0.150, 0.200),
+            _ph("oʊ", 0.200, 0.350),
+        ]
+        groups = ["voiceless_fricatives", "front_vowels", "laterals", "diphthongs"]
+        syls = syllabify_ipa(phonemes, groups, "hello", 0)
+        assert len(syls) == 2
+        # First syllable: h + ɛ (+ possibly l as coda)
+        # Second syllable: oʊ (+ possibly l as onset)
+        # Timestamps should be exactly as given, not recalculated
+        assert syls[0].start == 0.033
+        assert syls[-1].end == 0.350
+
+    def test_empty_phonemes(self):
+        syls = syllabify_ipa([], [], "empty", 0)
+        assert syls == []
+
+    def test_mismatched_lengths_raises(self):
+        phonemes = [_ph("k", 0.0, 0.1)]
+        groups = ["voiced_stops", "extra"]
+        with pytest.raises(ValueError, match="must have same length"):
+            syllabify_ipa(phonemes, groups, "bad", 0)
+
+    def test_word_metadata(self):
+        """Syllables carry correct word and word_index."""
+        phonemes = [
+            _ph("b", 0.0, 0.05),
+            _ph("ʌ", 0.05, 0.15),
+            _ph("t", 0.15, 0.22),
+            _ph("ə", 0.22, 0.30),
+            _ph("ɹ", 0.30, 0.38),
+        ]
+        groups = [
+            "voiced_stops", "central_vowels", "voiced_stops",
+            "central_vowels", "rhotics",
+        ]
+        syls = syllabify_ipa(phonemes, groups, "butter", 5)
+        for syl in syls:
+            assert syl.word == "butter"
+            assert syl.word_index == 5
+
+    def test_all_silence_returns_empty(self):
+        """All-silence input should return empty list."""
+        phonemes = [_ph("", 0.0, 0.1), _ph("", 0.1, 0.2)]
+        groups = ["silence", "silence"]
+        syls = syllabify_ipa(phonemes, groups, "silence", 0)
+        assert syls == []
+
+    def test_diphthong_as_nucleus(self):
+        """Diphthongs should be treated as vowel nuclei."""
+        phonemes = [
+            _ph("b", 0.0, 0.05),
+            _ph("aɪ", 0.05, 0.20),
+            _ph("t", 0.20, 0.28),
+        ]
+        groups = ["voiced_stops", "diphthongs", "voiced_stops"]
+        syls = syllabify_ipa(phonemes, groups, "bite", 0)
+        assert len(syls) == 1
+        assert len(syls[0].phonemes) == 3


### PR DESCRIPTION
## Summary
- Adds Bournemouth Forced Aligner (BFA) as an optional alignment backend for real phoneme-level timestamps from audio signal
- New `--aligner auto` default: tries BFA first, falls back to proportional timing if BFA/espeak-ng not installed
- IPA sonority-based syllabifier using BFA's pg16 phoneme group classifications
- CI updated to install espeak-ng + bournemouth-forced-aligner

## Test plan
- [x] 165 tests passing (53 new) — IPA syllabifier, BFA backend, aligner registry, CLI args
- [ ] Manual test: run with `--aligner bfa` on real audio, compare syllable cuts to `--aligner default`
- [ ] CI workflow: verify BFA installs and runs in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)