### PR TITLE
feat: switch bots to glottisdale Rust binary

### DIFF
--- a/.github/workflows/glottisdale.yml
+++ b/.github/workflows/glottisdale.yml
@@ -30,24 +30,29 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Cache Whisper + alignment models
+      - name: Cache Whisper models
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/whisper
-            ~/.cache/torch
-            ~/.cache/bournemouth_aligner
-          key: glottisdale-models-bfa-${{ inputs.whisper_model || 'base' }}
+          path: ~/.cache/whisper
+          key: whisper-models-${{ inputs.whisper_model || 'base' }}
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg espeak-ng librubberband-dev
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       - name: Install Python dependencies
         run: |
-          pip install torch torchaudio torchcodec --index-url https://download.pytorch.org/whl/cpu
+          pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+          pip install openai-whisper
           pip install -r glottisdale-bot/requirements.txt
-          pip install "glottisdale[bfa] @ git+https://github.com/A-U-Supply/glottisdale.git"
-          python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng')"
+
+      - name: Download glottisdale binary
+        run: |
+          gh release download --repo A-U-Supply/glottisdale --pattern 'glottisdale-linux-amd64' --dir /tmp
+          chmod +x /tmp/glottisdale-linux-amd64
+          sudo mv /tmp/glottisdale-linux-amd64 /usr/local/bin/glottisdale
+          glottisdale --version
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Run glottisdale
         env:

--- a/.github/workflows/hymnal-gargler.yml
+++ b/.github/workflows/hymnal-gargler.yml
@@ -41,25 +41,32 @@ jobs:
           cache: 'npm'
           cache-dependency-path: hymnal-bot/package-lock.json
 
-      - name: Cache Whisper + torch models
+      - name: Cache Whisper models
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/whisper
-            ~/.cache/torch
-          key: hymnal-gargler-models-${{ inputs.whisper_model || 'base' }}
+          path: ~/.cache/whisper
+          key: whisper-models-${{ inputs.whisper_model || 'base' }}
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg librubberband-dev
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       - name: Install Python dependencies
         run: |
           pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+          pip install openai-whisper
           pip install -r hymnal-bot/requirements.txt
-          python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng')"
 
       - name: Install Node.js dependencies
         run: cd hymnal-bot && npm ci
+
+      - name: Download glottisdale binary
+        run: |
+          gh release download --repo A-U-Supply/glottisdale --pattern 'glottisdale-linux-amd64' --dir /tmp
+          chmod +x /tmp/glottisdale-linux-amd64
+          sudo mv /tmp/glottisdale-linux-amd64 /usr/local/bin/glottisdale
+          glottisdale --version
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Run Hymnal Gargler
         env:

--- a/glottisdale-bot/bot.py
+++ b/glottisdale-bot/bot.py
@@ -1,12 +1,14 @@
 """Glottisdale Slack bot — fetches videos, runs collage, posts results.
 
-This is a thin wrapper around the glottisdale library. The library handles
-the audio processing; this script handles Slack I/O.
+This is a thin wrapper that handles Slack I/O and invokes the glottisdale
+Rust CLI binary for audio processing.
 """
 
 import argparse
+import json
 import logging
 import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -14,7 +16,6 @@ from pathlib import Path
 # Add bot directory to path for glottisdale_slack package
 sys.path.insert(0, str(Path(__file__).parent))
 
-from glottisdale.collage import process
 from glottisdale_slack.fetch import fetch_videos
 from glottisdale_slack.post import post_results
 
@@ -38,6 +39,55 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def run_glottisdale_cli(video_paths: list[Path], args) -> dict:
+    """Run the glottisdale CLI binary and return parsed output info."""
+    cmd = [
+        "glottisdale", "collage",
+        *[str(p) for p in video_paths],
+        "--output-dir", args.output_dir,
+        "--target-duration", str(args.target_duration),
+        "--whisper-model", args.whisper_model,
+        "--aligner", args.aligner,
+    ]
+    if args.seed is not None:
+        cmd.extend(["--seed", str(args.seed)])
+
+    logger.info(f"Running: {' '.join(cmd)}")
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        logger.error(f"CLI stderr: {result.stderr}")
+        raise RuntimeError(f"glottisdale CLI failed: {result.stderr.strip().splitlines()[-1]}")
+
+    # Parse stdout for output path and clip count
+    info = {"output": None, "clip_count": 0, "run_dir": None}
+    for line in result.stdout.splitlines():
+        if line.startswith("Output: "):
+            info["output"] = Path(line.split("Output: ", 1)[1].strip())
+            info["run_dir"] = info["output"].parent
+        elif line.startswith("Selected "):
+            try:
+                info["clip_count"] = int(line.split()[1])
+            except (IndexError, ValueError):
+                pass
+
+    if not info["output"] or not info["output"].exists():
+        raise RuntimeError(f"CLI did not produce expected output. stdout: {result.stdout}")
+
+    # Read manifest for per-source clip counts
+    manifest_path = info["run_dir"] / "manifest.json"
+    if manifest_path.exists():
+        info["manifest"] = json.loads(manifest_path.read_text())
+
+    logger.info(f"CLI output: {info['output']} ({info['clip_count']} clips)")
+    return info
+
+
 def main():
     logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s: %(message)s")
     args = build_parser().parse_args()
@@ -59,24 +109,29 @@ def main():
             print("No videos found in channel", file=sys.stderr)
             sys.exit(1)
 
-        result = process(
-            input_paths=[v["path"] for v in videos],
-            output_dir=args.output_dir,
-            target_duration=args.target_duration,
-            aligner=args.aligner,
-            whisper_model=args.whisper_model,
-            seed=args.seed,
+        info = run_glottisdale_cli(
+            video_paths=[v["path"] for v in videos],
+            args=args,
         )
 
-        logger.info(f"Processed {len(videos)} video(s), {len(result.clips)} clips")
+        logger.info(f"Processed {len(videos)} video(s), {info['clip_count']} clips")
 
         if not args.dry_run and not args.no_post:
+            # Count clips per source from manifest
+            manifest = info.get("manifest", {})
+            source_clip_counts = {}
+            for clip in manifest.get("clips", []):
+                source = clip.get("source", "")
+                source_clip_counts[source] = source_clip_counts.get(source, 0) + 1
+
             post_results(
                 token=token,
                 channel=args.dest_channel,
-                result=result,
+                concatenated_path=info["output"],
+                run_dir=info["run_dir"],
+                clip_count=info["clip_count"],
                 sources=videos,
-                output_dir=Path(args.output_dir),
+                source_clip_counts=source_clip_counts,
             )
 
 

--- a/glottisdale-bot/glottisdale_slack/post.py
+++ b/glottisdale-bot/glottisdale_slack/post.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from slack_sdk import WebClient
 
-from glottisdale.types import Result
 from glottisdale_slack.fetch import find_channel_id
 
 logger = logging.getLogger(__name__)
@@ -55,9 +54,11 @@ def _get_thread_ts(client: WebClient, file_id: str, max_attempts: int = 5) -> tu
 def post_results(
     token: str,
     channel: str,
-    result: Result,
+    concatenated_path: Path,
+    run_dir: Path,
+    clip_count: int,
     sources: list[dict],
-    output_dir: Path,
+    source_clip_counts: dict[str, int] | None = None,
     _client: WebClient | None = None,
 ) -> None:
     """Post glottisdale results to a Slack channel.
@@ -69,7 +70,7 @@ def post_results(
     client = _client or WebClient(token=token, timeout=120)
 
     today = date.today().isoformat()
-    summary = f":scissors: *Glottisdale* — {len(result.clips)} words from {len(sources)} source(s)"
+    summary = f":scissors: *Glottisdale* — {clip_count} words from {len(sources)} source(s)"
 
     # Resolve channel name to ID (files_upload_v2 requires channel ID)
     channel_id = find_channel_id(client, channel) if channel.startswith("#") else channel
@@ -78,17 +79,16 @@ def post_results(
     _log(f"Resolved channel {channel} -> {channel_id}")
 
     # === WAV UPLOAD — MANDATORY, MUST SUCCEED ===
-    concat_path = result.concatenated
-    if not concat_path.exists():
-        raise FileNotFoundError(f"Concatenated audio not found: {concat_path}")
+    if not concatenated_path.exists():
+        raise FileNotFoundError(f"Concatenated audio not found: {concatenated_path}")
 
-    file_size = concat_path.stat().st_size
-    _log(f"Uploading WAV: {concat_path} ({file_size} bytes)")
+    file_size = concatenated_path.stat().st_size
+    _log(f"Uploading WAV: {concatenated_path} ({file_size} bytes)")
 
     resp = _upload_with_retry(
         client,
         channel=channel_id,
-        file=str(concat_path),
+        file=str(concatenated_path),
         filename=f"glottisdale-{today}.wav",
         initial_comment=summary,
     )
@@ -115,11 +115,12 @@ def post_results(
         for src in sources:
             name = src.get("name", "unknown")
             link = src.get("permalink", "")
-            clip_count = len([c for c in result.clips if c.source == Path(name).stem])
+            stem = Path(name).stem
+            count = (source_clip_counts or {}).get(stem, 0)
             if link:
-                source_lines.append(f"  - <{link}|{name}> ({clip_count} words)")
+                source_lines.append(f"  - <{link}|{name}> ({count} words)")
             else:
-                source_lines.append(f"  - {name} ({clip_count} words)")
+                source_lines.append(f"  - {name} ({count} words)")
         try:
             client.chat_postMessage(
                 channel=channel_id,
@@ -132,7 +133,7 @@ def post_results(
             _log("Source links failed (non-fatal)")
 
     # Upload clips zip in thread (after source links)
-    zip_path = output_dir / "clips.zip"
+    zip_path = run_dir / "clips.zip"
     if zip_path.exists() and thread_ts:
         _log(f"Uploading zip in thread: {zip_path}")
         try:

--- a/glottisdale-bot/requirements.txt
+++ b/glottisdale-bot/requirements.txt
@@ -1,1 +1,2 @@
-glottisdale[slack] @ git+https://github.com/A-U-Supply/glottisdale.git
+slack-sdk>=3.0
+requests>=2.28

--- a/hymnal-bot/bot.py
+++ b/hymnal-bot/bot.py
@@ -1,24 +1,18 @@
 """Hymnal Gargler Slack bot — fetches MIDI + videos, runs sing pipeline, posts results.
 
-This is a thin wrapper around the glottisdale library. The library handles
-audio processing and vocal MIDI mapping; this script handles Slack I/O and
-Magenta.js MIDI extension.
+This is a thin wrapper that handles Slack I/O and MIDI extension, then invokes
+the glottisdale Rust CLI binary for vocal MIDI mapping.
 """
 
 import argparse
 import logging
 import os
+import subprocess
 import sys
 from pathlib import Path
-from statistics import median
 
 # Add bot directory to path for local modules
 sys.path.insert(0, str(Path(__file__).parent))
-
-from glottisdale.sing.midi_parser import parse_midi
-from glottisdale.sing.syllable_prep import prepare_syllables
-from glottisdale.sing.vocal_mapper import plan_note_mapping, render_vocal_track
-from glottisdale.sing.mixer import mix_tracks
 
 logger = logging.getLogger(__name__)
 
@@ -55,30 +49,56 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def run_glottisdale_sing(audio_paths: list[Path], midi_dir: Path, args) -> dict:
+    """Run the glottisdale sing CLI and return parsed output info."""
+    cmd = [
+        "glottisdale", "sing",
+        *[str(p) for p in audio_paths],
+        "--midi", str(midi_dir),
+        "--output-dir", str(args.output_dir),
+        "--target-duration", str(args.target_duration),
+        "--whisper-model", args.whisper_model,
+        "--drift-range", str(args.drift_range),
+    ]
+    if args.seed is not None:
+        cmd.extend(["--seed", str(args.seed)])
+    if not args.vibrato:
+        cmd.append("--no-vibrato")
+    if not args.chorus:
+        cmd.append("--no-chorus")
+
+    logger.info(f"Running: {' '.join(cmd)}")
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        logger.error(f"CLI stderr: {result.stderr}")
+        raise RuntimeError(f"glottisdale sing failed: {result.stderr.strip().splitlines()[-1]}")
+
+    info = {"full_mix": None, "acappella": None}
+    for line in result.stdout.splitlines():
+        if line.startswith("Output: "):
+            info["full_mix"] = Path(line.split("Output: ", 1)[1].strip())
+        elif line.startswith("A cappella: "):
+            info["acappella"] = Path(line.split("A cappella: ", 1)[1].strip())
+
+    if not info["full_mix"] or not info["full_mix"].exists():
+        raise RuntimeError(f"CLI did not produce expected output. stdout: {result.stdout}")
+
+    logger.info(f"Output: {info['full_mix']}, A cappella: {info['acappella']}")
+    return info
+
+
 def _run_local(args):
     """Run in local mode with provided MIDI and audio files."""
-    output_dir = args.output_dir
-    output_dir.mkdir(parents=True, exist_ok=True)
-    work_dir = output_dir / "work"
-    work_dir.mkdir(parents=True, exist_ok=True)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    track = parse_midi(args.midi / "melody.mid")
-    logger.info(f"Melody: {len(track.notes)} notes, {track.tempo} BPM, {track.total_duration:.1f}s")
-
-    syllables = prepare_syllables(args.audio, work_dir, args.whisper_model)
-    logger.info(f"Prepared {len(syllables)} syllables")
-
-    voiced_f0 = [s.f0 for s in syllables if s.f0 and s.f0 > 0]
-    median_f0 = median(voiced_f0) if voiced_f0 else 220.0
-
-    mappings = plan_note_mapping(
-        track.notes, len(syllables),
-        seed=args.seed, drift_range=args.drift_range,
+    info = run_glottisdale_sing(
+        audio_paths=args.audio,
+        midi_dir=args.midi,
+        args=args,
     )
-
-    acappella = render_vocal_track(mappings, syllables, work_dir, median_f0, args.target_duration)
-    full_mix, acappella_out = mix_tracks(acappella, args.midi, output_dir)
-    logger.info(f"Output: {full_mix}, A cappella: {acappella_out}")
+    logger.info(f"Output: {info['full_mix']}, A cappella: {info['acappella']}")
 
 
 def _run_slack(args):
@@ -92,9 +112,8 @@ def _run_slack(args):
         print("Error: SLACK_BOT_TOKEN required for Slack mode", file=sys.stderr)
         sys.exit(1)
 
-    output_dir = args.output_dir
-    output_dir.mkdir(parents=True, exist_ok=True)
-    work_dir = output_dir / "work"
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    work_dir = args.output_dir / "work"
     work_dir.mkdir(parents=True, exist_ok=True)
 
     # Fetch MIDI from #midieval
@@ -127,29 +146,20 @@ def _run_slack(args):
     video_dir.mkdir(parents=True, exist_ok=True)
     fetch_videos(token, video_dir, args.max_videos, args.video_channel)
 
-    # Parse extended melody
-    track = parse_midi(extended_dir / "melody.mid")
-    logger.info(f"Extended melody: {len(track.notes)} notes, {track.total_duration:.1f}s")
-
-    # Prepare syllables
     video_files = list(video_dir.glob("*"))
-    syllables = prepare_syllables(video_files, work_dir, args.whisper_model)
-    logger.info(f"Prepared {len(syllables)} syllables")
+    if not video_files:
+        print("No videos downloaded", file=sys.stderr)
+        sys.exit(1)
 
-    voiced_f0 = [s.f0 for s in syllables if s.f0 and s.f0 > 0]
-    median_f0 = median(voiced_f0) if voiced_f0 else 220.0
-
-    mappings = plan_note_mapping(
-        track.notes, len(syllables),
-        seed=args.seed, drift_range=args.drift_range,
+    # Run glottisdale sing
+    info = run_glottisdale_sing(
+        audio_paths=video_files,
+        midi_dir=extended_dir,
+        args=args,
     )
 
-    acappella = render_vocal_track(mappings, syllables, work_dir, median_f0, args.target_duration)
-    full_mix, acappella_out = mix_tracks(acappella, extended_dir, output_dir)
-    logger.info(f"Output: {full_mix}, A cappella: {acappella_out}")
-
     if not args.dry_run and not args.no_post:
-        post_results(token, args.dest_channel, full_mix, acappella_out, metadata, permalink)
+        post_results(token, args.dest_channel, info["full_mix"], info["acappella"], metadata, permalink)
 
 
 def main():

--- a/hymnal-bot/requirements.txt
+++ b/hymnal-bot/requirements.txt
@@ -1,1 +1,2 @@
-glottisdale[sing,slack] @ git+https://github.com/A-U-Supply/glottisdale.git
+slack-sdk>=3.0
+requests>=2.28


### PR DESCRIPTION
## Summary
- Both glottisdale-bot and hymnal-bot now invoke the glottisdale Rust CLI binary via subprocess instead of importing the Python glottisdale library
- Workflows download pre-built binary from [glottisdale v0.1.0 release](https://github.com/A-U-Supply/glottisdale/releases/tag/v0.1.0)
- Removed dependency on `glottisdale[bfa]` Python package (and its transitive deps: scipy, numpy, g2p_en, nltk, bournemouth-forced-aligner)

## Changes
- `glottisdale-bot/bot.py`: subprocess calls `glottisdale collage`, parses stdout + manifest.json for results
- `glottisdale-bot/glottisdale_slack/post.py`: accepts file paths instead of `glottisdale.types.Result` object
- `hymnal-bot/bot.py`: subprocess calls `glottisdale sing`, parses stdout for output paths
- Both `requirements.txt`: simplified to just `slack-sdk` + `requests`
- `glottisdale.yml`: downloads binary from GitHub Releases, removes BFA/NLTK deps
- `hymnal-gargler.yml`: downloads binary from GitHub Releases, removes glottisdale Python deps

## Test plan
- [ ] Manual dispatch of glottisdale workflow
- [ ] Manual dispatch of hymnal-gargler workflow
- [ ] Verify Slack posts appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)