### PR TITLE
fix(workflows): handle parallel bot pushes + stop scanning history

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+history/** linguist-vendored linguist-generated

--- a/.github/workflows/daily-midi.yml
+++ b/.github/workflows/daily-midi.yml
@@ -45,6 +45,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add midi-bot/used-song-titles.json
-          git diff --staged --quiet || git commit -m "chore: update midi-bot song title usage [skip ci]"
-          git pull --rebase || true
-          git push || true
+          if git diff --staged --quiet; then
+            echo "No usage changes to commit."
+          else
+            git commit -m "chore: update midi-bot song title usage [skip ci]"
+            for i in 1 2 3; do
+              git pull --rebase origin master && git push && break
+              echo "Push attempt $i failed; retrying..."
+              sleep 2
+            done
+          fi

--- a/.github/workflows/generate-history.yml
+++ b/.github/workflows/generate-history.yml
@@ -33,5 +33,9 @@ jobs:
             echo "No new snapshots to commit."
           else
             git commit -m "chore: generate history snapshots [skip ci]"
-            git push
+            for i in 1 2 3; do
+              git pull --rebase origin master && git push && break
+              echo "Push attempt $i failed; retrying..."
+              sleep 2
+            done
           fi

--- a/.github/workflows/glottisdale.yml
+++ b/.github/workflows/glottisdale.yml
@@ -75,6 +75,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add glottisdale-bot/used-song-titles.json
-          git diff --staged --quiet || git commit -m "chore: update glottisdale song title usage [skip ci]"
-          git pull --rebase || true
-          git push || true
+          if git diff --staged --quiet; then
+            echo "No usage changes to commit."
+          else
+            git commit -m "chore: update glottisdale song title usage [skip ci]"
+            for i in 1 2 3; do
+              git pull --rebase origin master && git push && break
+              echo "Push attempt $i failed; retrying..."
+              sleep 2
+            done
+          fi

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -95,5 +95,9 @@ jobs:
             echo "No changes to commit."
           else
             git commit -m "chore: optimize mire images and update HTML [skip ci]"
-            git push
+            for i in 1 2 3; do
+              git pull --rebase origin master && git push && break
+              echo "Push attempt $i failed; retrying..."
+              sleep 2
+            done
           fi

--- a/.github/workflows/puke-box.yml
+++ b/.github/workflows/puke-box.yml
@@ -40,5 +40,9 @@ jobs:
             echo "No new entries to commit."
           else
             git commit -m "chore: archive midieval entries ($(date -u +%Y-%m-%d)) [skip ci]"
-            git push
+            for i in 1 2 3; do
+              git pull --rebase origin master && git push && break
+              echo "Push attempt $i failed; retrying..."
+              sleep 2
+            done
           fi

--- a/.github/workflows/scrape-drawma.yml
+++ b/.github/workflows/scrape-drawma.yml
@@ -38,5 +38,9 @@ jobs:
             echo "No new images to commit."
           else
             git commit -m "chore: add drawma gallery images ($(date -u +%Y-%m-%d)) [skip ci]"
-            git push
+            for i in 1 2 3; do
+              git pull --rebase origin master && git push && break
+              echo "Push attempt $i failed; retrying..."
+              sleep 2
+            done
           fi

--- a/.github/workflows/song-titles.yml
+++ b/.github/workflows/song-titles.yml
@@ -35,6 +35,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add song-titles-bot/titles.json this-song-is-a-junkyard.html
-          git diff --staged --quiet || git commit -m "chore: update song titles ($(date +%Y-%m-%d)) [skip ci]"
-          git pull --rebase || true
-          git push || true
+          if git diff --staged --quiet; then
+            echo "No song-title changes to commit."
+          else
+            git commit -m "chore: update song titles ($(date +%Y-%m-%d)) [skip ci]"
+            for i in 1 2 3; do
+              git pull --rebase origin master && git push && break
+              echo "Push attempt $i failed; retrying..."
+              sleep 2
+            done
+          fi


### PR DESCRIPTION
## Summary
- Add pull-rebase + retry loop to all bot push steps (puke-box, drawma, daily-midi, song-titles, generate-history, glottisdale, optimize-images) so parallel daily pushes don't race
- Drop `|| true` masks that were hiding push failures
- Mark history/** as vendored so Dependabot stops creating failing security-update runs on frozen lockfiles

## Test plan
- [x] Drawma re-run succeeded (run 25974636284)
- [ ] Puke Box re-run after merge