### PR TITLE
fix(deploy-dokku): inline safe.directory for legacy-site pull

### DIFF
--- a/.github/workflows/deploy-dokku.yml
+++ b/.github/workflows/deploy-dokku.yml
@@ -19,4 +19,4 @@ jobs:
 
       - name: Pull latest on server
         run: |
-          ssh dokku@204.168.201.89 run au-supply git -C /srv/legacy-site pull --ff-only
+          ssh dokku@204.168.201.89 run au-supply git -c safe.directory=/srv/legacy-site -C /srv/legacy-site pull --ff-only


### PR DESCRIPTION
Pass `-c safe.directory=/srv/legacy-site` on the git command directly since `dokku run` containers are ephemeral and `git config --global` doesn't persist. Fixes the dubious-ownership failure that's been blocking deploys since April.