### PR TITLE
fix(workflows): restore workflow_dispatch triggers

### DIFF
--- a/.github/workflows/glottisdale.yml
+++ b/.github/workflows/glottisdale.yml
@@ -1,22 +1,20 @@
 name: Glottisdale
 
 on:
-  # schedule:
-  #   - cron: '0 18 * * *'  # 10am PT daily
-  # workflow_dispatch:
-  #   inputs:
-  #     target_duration:
-  #       description: 'Target duration in seconds'
-  #       default: '60'
-  #     max_videos:
-  #       description: 'Max source videos'
-  #       default: '5'
-  #     whisper_model:
-  #       description: 'Whisper model (tiny/base/small)'
-  #       default: 'base'
-  #     seed:
-  #       description: 'RNG seed (empty for random)'
-  #       default: ''
+  workflow_dispatch:
+    inputs:
+      target_duration:
+        description: 'Target duration in seconds'
+        default: '60'
+      max_videos:
+        description: 'Max source videos'
+        default: '5'
+      whisper_model:
+        description: 'Whisper model (tiny/base/small)'
+        default: 'base'
+      seed:
+        description: 'RNG seed (empty for random)'
+        default: ''
 
 permissions:
   contents: write

--- a/.github/workflows/hymnal-gargler.yml
+++ b/.github/workflows/hymnal-gargler.yml
@@ -1,26 +1,24 @@
 name: Hymnal Gargler
 
 on:
-  # schedule:
-  #   - cron: '0 23 * * *'  # 3pm PT daily
-  # workflow_dispatch:
-  #   inputs:
-  #     target_duration:
-  #       description: 'Target duration in seconds'
-  #       default: '40'
-  #     max_videos:
-  #       description: 'Max source videos'
-  #       default: '5'
-  #     whisper_model:
-  #       description: 'Whisper model (tiny/base/small)'
-  #       default: 'base'
-  #     seed:
-  #       description: 'RNG seed (empty for random)'
-  #       default: ''
-  #     dry_run:
-  #       description: 'Dry run (skip Slack post)'
-  #       type: boolean
-  #       default: false
+  workflow_dispatch:
+    inputs:
+      target_duration:
+        description: 'Target duration in seconds'
+        default: '40'
+      max_videos:
+        description: 'Max source videos'
+        default: '5'
+      whisper_model:
+        description: 'Whisper model (tiny/base/small)'
+        default: 'base'
+      seed:
+        description: 'RNG seed (empty for random)'
+        default: ''
+      dry_run:
+        description: 'Dry run (skip Slack post)'
+        type: boolean
+        default: false
 
 jobs:
   hymnal-gargler:


### PR DESCRIPTION
glottisdale.yml + hymnal-gargler.yml had every trigger commented out, leaving an empty `on:` block. GitHub flagged these as invalid on every push, surfacing as 'failed' runs with no jobs.